### PR TITLE
Configuration for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Validate this file using http://lint.travis-ci.org/
 language: python
 python:
-  - "2.5"
+#  - "2.5"
   - "2.6"
   - "2.7"
 install:


### PR DESCRIPTION
This branch adds a configuration for [Travis CI](http://travis-ci.org), "A hosted continuous integration service for the open source community."

It integrates with GitHub's service hooks, such that it automatically runs builds and tests (on Python versions of your choice) at every commit. [Example](http://travis-ci.org/#!/martijnvermaat/PyVCF).

I think this might be nice for PyVCF, especially in supporting different Python versions.

In this configuration, I enabled Python 2.6 and 2.7 (installing `argparse` on the former). For full test coverage, `pysam` is always installed.

For the moment I disabled Python 2.5, but the only thing holding the tests from passing is `collections.namedtuple` (and `pysam` does not support it, but we can do without it). Travis CI also has Python 3.1 and 3.2.
