### PR TITLE
Handle String INFO values when Number=1 in header

### DIFF
--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -571,7 +571,7 @@ class Reader(object):
                 val = entry[1]
 
             try:
-                if self.infos[ID].num == 1:
+                if self.infos[ID].num == 1 and entry_type != 'String':
                     val = val[0]
             except KeyError:
                 pass


### PR DESCRIPTION
Hi,

This patch fixes a bug that prevented full String values from being returned when the INFO tag is defined as String and Number = 1.  This offending block of code in `_parse_info` is:

```
try:
    if self.infos[ID].num == 1:
        val = val[0]
```

which is intended to set `val` to the first element in a list if the Number=1 in the header.  However, Strings values must be handled separately, otherwise only the first character of the string is returned.

```
try:
    if self.infos[ID].num == 1 and entry_type != 'String':
        val = val[0]
```

Example file (snippet):

```
##INFO=<ID=SNPEFF_GENE_NAME,Number=1,Type=String,Description="Gene name for the highest-impact effect resulting from the current variant">
#CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO    
1       10523   .       TCCG    T       62      PASS    AC=5;AF=0.0023;AFR_AF=0.01;AMR_AF=0.0028;AN=2184;AVGPOST=0.9920;ERATE=0.0028;LDAF=0.0063;RSQ=0.4021;SNPEFF_EFFECT=DOWNSTREAM;SNPEFF_FUNCTIONAL_CLASS=NONE;SNPEFF_GENE_BIOTYPE=unprocessed_pseudogene;SNPEFF_GENE_NAME=RP11-34P13.2;SNPEFF_IMPACT=MODIFIER;SNPEFF_TRANSCRIPT_ID=ENST00000423562;THETA=0.0063;VT=INDEL
```

Old:

```
>>> print var.INFO['SNPEFF_GENE_NAME']
'R'
```

New:

```
>>> print var.INFO['SNPEFF_GENE_NAME']
'RP11-34P13.2'
```
