### PR TITLE
improvments to vcf_filter

### DIFF
--- a/vcf/filters.py
+++ b/vcf/filters.py
@@ -36,7 +36,7 @@ class SiteQuality(Base):
     @classmethod
     def customize_parser(self, parser):
         parser.add_argument('--site-quality', type=int, default=30,
-                help='Filter sites below this quality [30]')
+                help='Filter sites below this quality')
 
     def __init__(self, args):
         self.threshold = args.site_quality
@@ -54,7 +54,7 @@ class VariantGenotypeQuality(Base):
     @classmethod
     def customize_parser(self, parser):
         parser.add_argument('--genotype-quality', type=int, default=50,
-                help='Filter sites with no genotypes above this quality [50]')
+                help='Filter sites with no genotypes above this quality')
 
     def __init__(self, args):
         self.threshold = args.genotype_quality


### PR DESCRIPTION
I like the idea of vcf filtering framework, so I tried to use that for my project. To be able to use that fluently, i've added few changes.
#### Filter classes can be contained in local file

The file is given on the command line, so not all the possible arguments are known the first time command line is parsed. So it was necessary to slightly change the command syntax to

<pre>
vcf_filter.py --optionals input filter1 [--filter1-optionals] 
  [filter2 [--filter2-optionals]]
</pre>


This way the arguments can be parsed filter by filter and checked for correctness.
#### Output 'PASS' in filter field only if filtered data are not dropped
#### Small change to `add_filter()` to remove the '.' when adding first filter
