### PR TITLE
Make metadata RE reluctant (stop on first = not last)

### DIFF
--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -159,7 +159,7 @@ class _vcf_metadata_parser(object):
             Type=(?P<type>.+),
             Description="(?P<desc>.*)"
             >''', re.VERBOSE)
-        self.meta_pattern = re.compile(r'''##(?P<key>.+)=(?P<val>.+)''')
+        self.meta_pattern = re.compile(r'''##(?P<key>.+?)=(?P<val>.+)''')
 
     def vcf_field_count(self, num_str):
         if num_str == '.':


### PR DESCRIPTION
Thanks to @dzerbino for many fixes. The metadata hash added here: https://github.com/jamescasbon/PyVCF/commit/d928de1cbe6fdc056aaafb723dd9644d8c760dd3#L2R170
fixed mis-parsing contigs with internal =, but a UnifiedGenotyper metadata line isn't wrapped in angle brackets and is thus still parsed improperly. 

This is a very simple tweak to the RE: 

(.+)=(.+) will put everything up to the very **last** = in the first group because + is greedy by default. 

(.+?)=(.+) makes the + reluctant, so only the first group of characters that are not =, aka the key, will be in the first group.
