### PR TITLE
Fix writing of Number=A and G INFO/FORMAT fields

### DIFF
--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -1021,7 +1021,7 @@ class Writer(object):
             return self.counts[num_str]
 
     def _format_alt(self, alt):
-        return ','.join([str(x) or '.' for x in alt])
+        return ','.join(self._map(str, alt))
 
     def _format_info(self, info):
         if not info:


### PR DESCRIPTION
Currently, the Reader stores field Numbers of A and G as negative integers, and the Writer doesn't convert them back to letters. 

To make it easier to reverse the cast to integer, I changed the conversion method. Instead of converting using hard-coded if/elif, I've made a module-level dictionary for both conversion and reversal lookup. I'm using if/else because I've read that it's faster than try/except if the check is expected to fail over half the time, and I put `if not` first because it's more likely.

For writing the header fields, I switched to use str.format() (instead of C-style) and added a method that uses the conversion dictionary to switch the integers back to the correct letters. 

In the third commit I removed the '.' if None str() `_map`ped to each line. The dictionary handles None to '.' for the Number field. As far as I can tell from the spec, only Number is allowed to have a value of '.' -- if this is incorrect this commit can be skipped. 
