### PR TITLE
For pair formatting, check that a flag is true

### DIFF
--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -1080,7 +1080,7 @@ class Writer(object):
         return str(x) if x is not None else none
 
     def _stringify_pair(self, x, y, none='.', delim=','):
-        if isinstance(y, bool):
+        if y and isinstance(y, bool):
             return str(x)
         return "%s=%s" % (str(x), self._stringify(y, none=none, delim=delim))
 


### PR DESCRIPTION
Added "if y" so a manually-set "DB=False" won't print as ";DB;"
