### PR TITLE
Minor patch to Flag output; add ability to explicitly flush/close Writer stream 

### DIFF
--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -1067,11 +1067,17 @@ class Writer(object):
 
     def flush(self):
         """Flush the writer"""
-        self.stream.flush()
+        try:
+            self.stream.flush()
+        except AttributeError:
+            pass
 
     def close(self):
         """Close the writer"""
-        self.stream.close()
+        try:
+            self.stream.close()
+        except AttributeError:
+            pass
 
     def _fix_field_count(self, num_str):
         """Restore header number to original state"""


### PR DESCRIPTION
Modified the Flag output for False entries to print an empty string, rather than "FLAG=False".

Added the stream object as an attribute of Writer to enable the ability to explicitly flush and close the stream.  For programs that write a VCF, then perform manipulations upon it (e.g. bgzip + tabix), it is imperative that the buffer is flushed prior to beginning any further manipulations on the written VCF.  Currently, to achieve this behavior you have to either keep a reference to the file object itself or delete the Writer object and hope that the Python implementation used closes files upon deletion.

http://stackoverflow.com/questions/3976711/csvwriter-not-saving-data-to-file-why
http://python.6.n6.nabble.com/CSV-writer-question-td1421639.html
