### PR TITLE
Ignore empty lines

### DIFF
--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -198,7 +198,7 @@ class Reader(object):
             if sys.version > '3':
                 self._reader = codecs.getreader('ascii')(self._reader)
 
-        self.reader = (line for line in self._reader if line.rstrip())
+        self.reader = (line.strip() for line in self._reader if line.strip())
 
         #: metadata fields from header (string or hash, depending)
         self.metadata = None
@@ -234,7 +234,6 @@ class Reader(object):
         line = self.reader.next()
         while line.startswith('##'):
             self._header_lines.append(line)
-            line = line.strip()
 
             if line.startswith('##INFO'):
                 key, val = parser.read_info(line)
@@ -253,7 +252,7 @@ class Reader(object):
                 self.formats[key] = val
 
             else:
-                key, val = parser.read_meta(line.strip())
+                key, val = parser.read_meta(line)
                 if key in SINGULAR_METADATA:
                     self.metadata[key] = val
                 else:
@@ -263,7 +262,7 @@ class Reader(object):
 
             line = self.reader.next()
 
-        fields = re.split('\t| +', line.rstrip())
+        fields = re.split('\t| +', line)
         self.samples = fields[9:]
         self._sample_indexes = dict([(x,i) for (i,x) in enumerate(self.samples)])
 
@@ -438,7 +437,7 @@ class Reader(object):
     def next(self):
         '''Return the next record in the file.'''
         line = self.reader.next()
-        row = re.split('\t| +', line.strip())
+        row = re.split('\t| +', line)
         chrom = row[0]
         if self._prepend_chr:
             chrom = 'chr' + chrom


### PR DESCRIPTION
This would probably fix #71. Strictly, I think the spec doesn't allow for empty lines, but hey.

This implementation is just a suggestion, I'm not sure about its performance implication. It would probably also make sense to look for other line.rstrip() calls to do that only once. Might add another commit for that.

It doesn't interfere with tabix fetching, but empty lines within a fetched region are not handled.
