### PR TITLE
Changed the rule to split records into columns

### DIFF
--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -437,7 +437,7 @@ class Reader(object):
     def next(self):
         '''Return the next record in the file.'''
         line = self.reader.next()
-        row = re.split('\t| +', line)
+        row = re.split('\t+', line)
         chrom = row[0]
         if self._prepend_chr:
             chrom = 'chr' + chrom


### PR DESCRIPTION
According to the specification the columns must be tab separated. I encountered an VCF file from NCBI that has spaces in the INFO column, which caused PyVCF to fail.
http://www.1000genomes.org/wiki/Analysis/Variant%20Call%20Format/vcf-variant-call-format-version-41
