### PR TITLE
Allow flexibility in parsing INFO values specified as integers in the header: also allow float values

### DIFF
--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -310,7 +310,12 @@ class Reader(object):
 
             if entry_type == 'Integer':
                 vals = entry[1].split(',')
-                val = self._map(int, vals)
+                try:
+                    val = self._map(int, vals)
+                # Allow specified integers to be flexibly parsed as floats.
+                # Handles cases with incorrectly specified header types.
+                except ValueError:
+                    val = self._map(float, vals)
             elif entry_type == 'Float':
                 vals = entry[1].split(',')
                 val = self._map(float, vals)
@@ -392,7 +397,10 @@ class Reader(object):
                 if entry_num == 1 or ',' not in vals:
 
                     if entry_type == 'Integer':
-                        sampdat[i] = int(vals)
+                        try:
+                            sampdat[i] = int(vals)
+                        except ValueError:
+                            sampdat[i] = float(vals)
                     elif entry_type == 'Float':
                         sampdat[i] = float(vals)
                     else:
@@ -406,7 +414,10 @@ class Reader(object):
                 vals = vals.split(',')
 
                 if entry_type == 'Integer':
-                    sampdat[i] = _map(int, vals)
+                    try:
+                        sampdat[i] = _map(int, vals)
+                    except ValueError:
+                        sampdat[i] = _map(float, vals)
                 elif entry_type == 'Float' or entry_type == 'Numeric':
                     sampdat[i] = _map(float, vals)
                 else:


### PR DESCRIPTION
Some GATK files have the GC keyval specified as an Integer in the header, but the actual values are floats. To be a bit more flexible this patch retries with float if int fails, allowing any number value to pass cleanly.
