### PR TITLE
Correctly format contig output lines from writer, making output VCFs compatible with GATK. Fixes #74

### DIFF
--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -549,12 +549,16 @@ class Writer(object):
 
         two = '##{key}=<ID={0},Description="{1}">\n'
         four = '##{key}=<ID={0},Number={num},Type={2},Description="{3}">\n'
+        contig_format = '##contig=<ID={ID},length={length},assembly={assembly}>\n'
         _num = self._fix_field_count
         for (key, vals) in template.metadata.iteritems():
             if key in SINGULAR_METADATA:
                 vals = [vals]
             for val in vals:
-                stream.write('##{0}={1}\n'.format(key, val))
+                if key == "contig":
+                    stream.write(contig_format.format(**val))
+                else:
+                    stream.write('##{0}={1}\n'.format(key, val))
         for line in template.infos.itervalues():
             stream.write(four.format(key="INFO", *line, num=_num(line.num)))
         for line in template.formats.itervalues():

--- a/vcf/test/test_vcf.py
+++ b/vcf/test/test_vcf.py
@@ -218,7 +218,11 @@ class TestGatkOutputWriter(unittest.TestCase):
         for record in records:
             writer.write_record(record)
         out.seek(0)
-        print (out.getvalue())
+        out_str = out.getvalue()
+        for line in out_str.split("\n"):
+            if line.startswith("##contig"):
+                assert "<ID=" in line, "Found dictionary in contig line: {0}".format(line)
+        print (out_str)
         reader2 = vcf.Reader(out)
 
         self.assertEquals(reader.samples, reader2.samples)


### PR DESCRIPTION
This is a fix for issue 74:

https://github.com/jamescasbon/PyVCF/issues/74

The raw dictionary output of PyVCF on contig lines causes errors if you process files downstream with GATK. This pull request detects and correctly formats "##contig" metadata. Includes an added test case to avoid regression.
