### PR TITLE
Correctly write meta lines with dictionary value

### DIFF
--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -158,7 +158,7 @@ class _vcf_metadata_parser(object):
         # Removing initial hash marks and final equal sign
         key = items[0][2:-1]
         hashItems = items[1].split(',')
-        val = dict(item.split("=") for item in hashItems)
+        val = OrderedDict(item.split("=") for item in hashItems)
         return key, val
 
     def read_meta(self, meta_string):

--- a/vcf/test/test_vcf.py
+++ b/vcf/test/test_vcf.py
@@ -273,7 +273,7 @@ class TestWriterDictionaryMeta(unittest.TestCase):
         out_str = out.getvalue()
         for line in out_str.split("\n"):
             if line.startswith("##PEDIGREE"):
-                assert line.startswith('##PEDIGREE=<'), "Found dictionary in meta line: {0}".format(line)
+                self.assertEquals(line, '##PEDIGREE=<Derived="Tumor",Original="Germline">')
             if line.startswith("##SAMPLE"):
                 assert line.startswith('##SAMPLE=<'), "Found dictionary in meta line: {0}".format(line)
 


### PR DESCRIPTION
Write meta lines with a dictionary-like value as

```
##meta=<field=value,field=value,...>
```

instead of as the Python dictionary string representation. This is a
fix for jamescasbon#83 and a generalization of jamescasbon#81. A
regression compared to jamescasbon#81 is that the order of fields in
a `contig` line is no longer defined.

The implementation still feels a bit hackish and there are probably other unknown cases not handled properly, but this should fix a bunch.
