### PR TITLE
Before installing pysam, install cython

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.2"
   - "pypy"
 install:
-  - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install --use-mirrors cython pysam argparse ordereddict; fi"
-  - "if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install --use-mirrors cython pysam; fi"
+  - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install --use-mirrors cython; pip install --use-mirrors pysam argparse ordereddict; fi"
+  - "if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install --use-mirrors cython; pip install --use-mirrors pysam; fi"
   - python setup.py install
-script: python setup.py test
+script: nosetests -v


### PR DESCRIPTION
I think [this commit](http://code.google.com/p/pysam/source/detail?spec=svn8cbb117dd2928a04fadbf5066a28e178afa4434b&r=730d8b44f5efc2c9a2ad3ed75bea89f934659891) in pysam breaks installation on Python 2.6 and 2.7 without Cython installed.

Tries to fix jamescasbon/#85
