### PR TITLE
support String type INFO fields with multiple values

### DIFF
--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -323,12 +323,13 @@ class Reader(object):
                 val = True
             elif entry_type == 'String':
                 try:
-                    val = entry[1]
+                    vals = entry[1].split(',') # commas are reserved characters indicating multiple values
+                    val = self._map(str, vals)
                 except IndexError:
                     val = True
 
             try:
-                if self.infos[ID].num == 1 and entry_type not in ( 'String', 'Flag'):
+                if self.infos[ID].num == 1 and entry_type not in ( 'Flag', ):
                     val = val[0]
             except KeyError:
                 pass

--- a/vcf/test/example-4.1-info-multiple-values.vcf
+++ b/vcf/test/example-4.1-info-multiple-values.vcf
@@ -1,0 +1,7 @@
+##fileformat=VCFv4.1
+##contig=<ID=Pf3D7_01_v3,length=640851>
+##INFO=<ID=RepeatCopies,Number=.,Type=Float,Description="Number of copies aligned with the consensus pattern">
+##INFO=<ID=RepeatSize,Number=.,Type=Integer,Description="Size of consensus pattern (may differ slightly from the period size)">
+##INFO=<ID=RepeatConsensus,Number=.,Type=String,Description="Repeat consensus sequence">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT
+Pf3D7_01_v3	401	.	C	T	53.99	PASS	RepeatCopies=19.3,47.4,14.0;RepeatSize=42,14,56;RepeatConsensus=TCTTATCTTCTTACTTTTCATTCCTTACTCTTACTTACTTAC,TTACTCTTACTTAC,TTACTCTTACTTACTTACTCTTACTTACTTACTCTTACTTACTTACTCTTATCTTC	

--- a/vcf/test/test_vcf.py
+++ b/vcf/test/test_vcf.py
@@ -571,6 +571,22 @@ class TestRecord(unittest.TestCase):
             self.assertEqual(expected, qual)
             self.assertEqual(type(expected), qtype)
 
+    def test_info_multiple_values(self):
+        reader = vcf.Reader(fh('example-4.1-info-multiple-values.vcf'))
+        var = reader.next()
+        # check Float type INFO field with multiple values
+        expected = [19.3, 47.4, 14.0]
+        actual = var.INFO['RepeatCopies']
+        self.assertEqual(expected, actual)
+        # check Integer type INFO field with multiple values
+        expected = [42, 14, 56]
+        actual = var.INFO['RepeatSize']
+        self.assertEqual(expected, actual)
+        # check String type INFO field with multiple values
+        expected = ['TCTTATCTTCTTACTTTTCATTCCTTACTCTTACTTACTTAC', 'TTACTCTTACTTAC', 'TTACTCTTACTTACTTACTCTTACTTACTTACTCTTACTTACTTACTCTTATCTTC']
+        actual = var.INFO['RepeatConsensus']
+        self.assertEqual(expected, actual)
+
 
 class TestCall(unittest.TestCase):
 


### PR DESCRIPTION
I have String type INFO fields with multiple values, but PyVCF currently does not split these by the comma char into multiple values, it returns a single string. I see that there is a special exception for String type INFO fields in the code handling multiple values, so maybe you have a good reason for doing this (some legacy VCFs that have commas in INFO fields where they shouldn't?) But the VCF 4.1 spec does state that comma is reserved in INFO fields values for specifying multiple values, so the current behaviour is not standard (and I have to add special cases in my VCF-handling code to work around).
