### PR TITLE
add support for contigs in the VCF header

### DIFF
--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -97,6 +97,7 @@ class _vcf_metadata_parser(object):
         self.contig_pattern = re.compile(r'''\#\#contig=<
             ID=(?P<id>[^,]+),
             length=(?P<length>-?\d+)
+            .*
             >''', re.VERBOSE)
         self.meta_pattern = re.compile(r'''##(?P<key>.+?)=(?P<val>.+)''')
 


### PR DESCRIPTION
This will allow us to compare the order of contigs in the vcf file, to say that "chr3" comes before "chr6" etc. when reading multiple vcf files.
