### PR TITLE
Differentiate between no filtering and PASS

### DIFF
--- a/scripts/vcf_filter.py
+++ b/scripts/vcf_filter.py
@@ -162,7 +162,7 @@ def main():
         if output_record:
             # use PASS only if other filter names appear in the FILTER column
             #FIXME: is this good idea?
-            if record.FILTER == '.' and not drop_filtered: record.FILTER = 'PASS'
+            if record.FILTER is None and not drop_filtered: record.FILTER = 'PASS'
             output.write_record(record)
 
 if __name__ == '__main__': main()

--- a/vcf/model.py
+++ b/vcf/model.py
@@ -163,7 +163,10 @@ class _Record(object):
         self.FORMAT = self.FORMAT + ':' + fmt
 
     def add_filter(self, flt):
-        self.FILTER.append(flt)
+        if self.FILTER is None:
+            self.FILTER = [flt]
+        else:
+            self.FILTER.append(flt)
 
     def add_info(self, info, value=True):
         self.INFO[info] = value

--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -541,7 +541,9 @@ class Reader(object):
                 qual = None
 
         filt = row[6]
-        if filt == 'PASS' or filt == '.':
+        if filt == '.':
+            filt = None
+        elif filt == 'PASS':
             filt = []
         else:
             filt = filt.split(';')

--- a/vcf/test/mixed-filtering.vcf
+++ b/vcf/test/mixed-filtering.vcf
@@ -1,0 +1,24 @@
+##fileformat=VCFv4.1
+##fileDate=20090805
+##source=myImputationProgramV3.1
+##reference=file:///seq/references/1000GenomesPilot-NCBI36.fasta
+##contig=<ID=20,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo sapiens",taxonomy=x>
+##phasing=partial
+##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of Samples With Data">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">
+##INFO=<ID=AA,Number=1,Type=String,Description="Ancestral Allele">
+##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP membership, build 129">
+##INFO=<ID=H2,Number=0,Type=Flag,Description="HapMap2 membership">
+##FILTER=<ID=q10,Description="Quality below 10">
+##FILTER=<ID=s50,Description="Less than 50% of samples have data">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth">
+##FORMAT=<ID=HQ,Number=2,Type=Integer,Description="Haplotype Quality">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA00001	NA00002	NA00003
+20	14370	rs6054257	G	A	29	PASS	NS=3;DP=14;AF=0.5;DB;H2	GT:GQ:DP:HQ	0|0:48:1:51,51	1|0:48:8:51,51	1/1:43:5:.,.
+20	17330	.	T	A	3	q10	NS=3;DP=11;AF=0.017	GT:GQ:DP:HQ	0|0:49:3:58,50	0|1:3:5:65,3	0/0:41:3
+20	1110696	rs6040355	A	G,T	67	PASS	NS=2;DP=10;AF=0.333,0.667;AA=T;DB	GT:GQ:DP:HQ	1|2:21:6:23,27	2|1:2:0:18,2	2/2:35:4
+20	1230237	.	T	.	47	.	NS=3;DP=13;AA=T	GT:GQ:DP:HQ	0|0:54:7:56,60	0|0:48:4:51,51	0/0:61:2
+20	1234567	microsat1	GTC	G,GTCT	50	q10;q50	NS=3;DP=9;AA=G	GT:GQ:DP	0/1:35:4	0/2:17:2	1/1:40:3

--- a/vcf/test/test_vcf.py
+++ b/vcf/test/test_vcf.py
@@ -327,6 +327,20 @@ class TestSamplesSpace(unittest.TestCase):
         self.assertEqual(self.reader.samples, self.samples)
 
 
+class TestMixedFiltering(unittest.TestCase):
+    filename = 'mixed-filtering.vcf'
+    def test_mixed_filtering(self):
+        """
+        Test mix of FILTER values (pass, filtered, no filtering).
+        """
+        reader = vcf.Reader(fh(self.filename))
+        self.assertEqual(next(reader).FILTER, [])
+        self.assertEqual(next(reader).FILTER, ['q10'])
+        self.assertEqual(next(reader).FILTER, [])
+        self.assertEqual(next(reader).FILTER, None)
+        self.assertEqual(next(reader).FILTER, ['q10', 'q50'])
+
+
 class TestRecord(unittest.TestCase):
 
     def test_num_calls(self):
@@ -898,6 +912,7 @@ suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestFilter))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(Test1kg))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(Test1kgSites))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestSamplesSpace))
+suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestMixedFiltering))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestRecord))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestCall))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestRegression))


### PR DESCRIPTION
Fixes #114

In #114, @AndrewUzilov proposes to track this in a separate field, but I actually think we should do it in a more direct way by explicitely storing `None` if there was no filtering.

Keeping it open for discussion, if there are no objections I'll merge it in a few days.
