### PR TITLE
Fixed tox.ini error regarding duplicate test section.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,6 @@ deps =
 deps = 
     cython
 
-[testenv:py32]
+[testenv:py33]
 deps = 
     cython


### PR DESCRIPTION
  File "/usr/local/bin/tox", line 9, in <module>
    load_entry_point('tox==1.6.1', 'console_scripts', 'tox')()
  File "/usr/local/lib/python2.7/dist-packages/tox/_cmdline.py", line
25, in main
    config = parseconfig(args, 'tox')
  File "/usr/local/lib/python2.7/dist-packages/tox/_config.py", line 44,
in parseconfig
    parseini(config, inipath)
  File "/usr/local/lib/python2.7/dist-packages/tox/_config.py", line
187, in __init__
    self._cfg = py.iniconfig.IniConfig(config.toxinipath)
  File "/usr/local/lib/python2.7/dist-packages/py/_iniconfig.py", line
67, in __init__
    self._raise(lineno, 'duplicate section %r'%(section, ))
  File "/usr/local/lib/python2.7/dist-packages/py/_iniconfig.py", line
75, in _raise
    raise ParseError(self.path, lineno, msg)
py._iniconfig.ParseError:
/home/smilefreak/MerrimanSelectionPipeline/PyVCF/tox.ini:30: duplicate
section 'testenv:py32'
