### PR TITLE
Add custom equality function as walk_together argument

### DIFF
--- a/vcf/test/walk_refcall.vcf
+++ b/vcf/test/walk_refcall.vcf
@@ -1,0 +1,22 @@
+##fileformat=VCFv4.0
+##fileDate=20090805
+##source=myImputationProgramV3.1
+##reference=1000GenomesPilot-NCBI36
+##phasing=partial
+##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of Samples With Data">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">
+##INFO=<ID=AF,Number=.,Type=Float,Description="Allele Frequency">
+##INFO=<ID=AA,Number=1,Type=String,Description="Ancestral Allele">
+##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP membership, build 129">
+##INFO=<ID=H2,Number=0,Type=Flag,Description="HapMap2 membership">
+##FILTER=<ID=q10,Description="Quality below 10">
+##FILTER=<ID=s50,Description="Less than 50% of samples have data">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth">
+##FORMAT=<ID=HQ,Number=2,Type=Integer,Description="Haplotype Quality">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA00001	NA00002	NA00003
+20	14370	rs6054257	G	.	29	PASS	NS=3;DP=14;AF=0.5;DB;H2	GT:GQ:DP:HQ	0|0:48:1:51,51	0|0:48:8:51,51	0/0:43:5:.,.
+20	17330	.	T	.	3.0	q10	NS=3;DP=11;AF=0.017	GT:GQ:DP:HQ	0|0:49:3:58,50	0|0:3:5:65,3	0/0:41:3
+20	1110696	rs6040355	A	.	1e+03	PASS	NS=2;DP=10;AF=0.333,0.667;AA=T;DB	GT:GQ:DP:HQ	0|0:21:6:23,27	0|0:2:0:18,2	0/0:35:4
+20	1230237	.	T	.	47	PASS	NS=3;DP=13;AA=T	GT:GQ:DP:HQ	0|0:54:7:56,60	0|0:48:4:51,51	0/0:61:2


### PR DESCRIPTION
The `walk_together` function is very useful for iterating over multiple VCF files. However, it breaks in some cases (e.g. comparing multiple single - sample VCF files with one containing reference calls) due to its definition of VCF record equality (which sometimes may be too strict).

This pull request adds the ability to use user-defined equality functions (e.g. if we want to compare only on Record positions and reference bases), while still leaving the original behavior intact. I should mention that this comes at a cost of a rather clunky usage of `**kwargs` in `walk_together`, but I think this is an acceptable trade off.

New test cases against this change have also been added and feedbacks are very welcomed :).
