### PR TITLE
Add dependency on collections.Counter implementation for Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - "3.3"
   - "pypy"
 install:
-  - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install --use-mirrors cython && pip install --use-mirrors pysam argparse ordereddict; fi"
+  - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install --use-mirrors cython && pip install --use-mirrors pysam argparse counter ordereddict; fi"
   - "if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install --use-mirrors cython && pip install --use-mirrors pysam; fi"
   - python setup.py install
 script: python setup.py test

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,12 @@ try:
 except ImportError:
     requires.append('argparse')
 
-
+import collections
 try:
-    import collections
+    collections.Counter
+except AttributeError:
+    requires.append('counter')
+try:
     collections.OrderedDict
 except AttributeError:
     requires.append('ordereddict')

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ commands =
 [testenv:py26]
 deps =
     argparse
+    counter
     ordereddict
     cython
     pysam
@@ -24,9 +25,9 @@ deps =
     cython
 
 [testenv:py32]
-deps = 
+deps =
     cython
 
 [testenv:py33]
-deps = 
+deps =
     cython

--- a/vcf/model.py
+++ b/vcf/model.py
@@ -2,6 +2,11 @@ from abc import ABCMeta, abstractmethod
 import collections
 import sys
 
+try:
+    from collections import Counter
+except ImportError:
+    from counter import Counter
+
 
 class _Call(object):
     """ A genotype call, a cell entry in a VCF file"""
@@ -211,7 +216,7 @@ class _Record(object):
            NOTE: Denominator calc'ed from _called_ genotypes.
         """
         num_chroms = 2.0 * self.num_called
-        allele_counts = collections.Counter()
+        allele_counts = Counter()
         for s in self.samples:
             if s.gt_type is not None:
                 allele_counts.update([s.gt_alleles[0]])


### PR DESCRIPTION
As per my suggestion in PR jamescasbon#131, defaultdict(int) was changed to Counter(). However, I didn't realize it was only added in Python 2.7 and we target Python 2.6.

This approach follows what we already did for collections.OrderedDict.

@jamescasbon, do you agree?
