### PR TITLE
Changed the default line ending in vcf.Writer() to '\n'.

### DIFF
--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -606,7 +606,7 @@ class Writer(object):
     # Reverse keys and values in header field count dictionary
     counts = dict((v,k) for k,v in field_counts.iteritems())
 
-    def __init__(self, stream, template, lineterminator="\r\n"):
+    def __init__(self, stream, template, lineterminator="\n"):
         self.writer = csv.writer(stream, delimiter="\t", lineterminator=lineterminator)
         self.template = template
         self.stream = stream


### PR DESCRIPTION
Currently, the default is '\r\n'. Most vcf files in public repositories use '\n' line endings. And vcf.Writer() writes the meta data directly with the original line ending '\n', but changes the record line ending to '\r\n' by default, which is quite confusing (and may cause compatibility issues). 

This is just a quick fix. A better way to approach this is to check the line ending in the orignal vcf file served as the template, and use it as default. I am not sure whether this is worth it though.
