### PR TITLE
Allow flag INFO field to be declared as string

### DIFF
--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -390,6 +390,7 @@ class Reader(object):
                     vals = entry[1].split(',') # commas are reserved characters indicating multiple values
                     val = self._map(str, vals)
                 except IndexError:
+                    entry_type = 'Flag'
                     val = True
 
             try:

--- a/vcf/test/string_as_flag.vcf
+++ b/vcf/test/string_as_flag.vcf
@@ -1,0 +1,8 @@
+##fileformat=VCFv4.1
+##INFO=<ID=AB,Number=1,Type=String,Description="Alt Base">
+##INFO=<ID=CD,Number=.,Type=String,Description="Alt Base">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	test
+chr2	21	.	A	G	.	.		GT	.
+chr2	24	.	G	T	.	.	AB	GT	.
+chr2	48	.	C	T	.	.	CD	GT	.
+chr2	75	.	T	C	.	.	AB;CD	GT	.

--- a/vcf/test/test_vcf.py
+++ b/vcf/test/test_vcf.py
@@ -262,6 +262,16 @@ class TestGoNL(unittest.TestCase):
         self.assertEqual(reader.contigs['1'].length, 249250621)
 
 
+class TestStringAsFlag(unittest.TestCase):
+
+    def test_string_as_flag(self):
+        """A flag INFO field is declared as string (not allowed by the spec,
+        but seen in practice)."""
+        reader = vcf.Reader(fh('string_as_flag.vcf', 'r'))
+        for _ in reader:
+            pass
+
+
 class TestInfoOrder(unittest.TestCase):
 
     def _assert_order(self, definitions, fields):
@@ -1339,6 +1349,7 @@ suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestBcfToolsOutput))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(Test1kg))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(Test1kgSites))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestGoNL))
+suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestStringAsFlag))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestInfoOrder))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestInfoTypeCharacter))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestGatkOutputWriter))


### PR DESCRIPTION
As reported in #164, we previously crashed on flag INFO fields declared as strings (and the number of values declared as 1). This is indeed not according to spec, but we should probably allow it anyway.
