### PR TITLE
Don't crash when FORMAT is set to the missing value (.)

### DIFF
--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -559,6 +559,9 @@ class Reader(object):
             fmt = row[8]
         except IndexError:
             fmt = None
+        else:
+            if fmt == '.':
+                fmt = None
 
         record = _Record(chrom, pos, ID, ref, alt, qual, filt,
                 info, fmt, self._sample_indexes)


### PR DESCRIPTION
It is not valid according to the spec, but issue #164 shows a VCF file where the FORMAT column contains just a dot character. We have no way of interpreting the subsequent genotype columns in that case, so this patch ignores them.
