### PR TITLE
Restrict pysam to version 0.7.8 for Python 3 tests to pass.

### DIFF
--- a/requirements/common-requirements.txt
+++ b/requirements/common-requirements.txt
@@ -1,3 +1,3 @@
 cython
-pysam==0.7.8
+pysam<=0.7.8
 setuptools


### PR DESCRIPTION
pysam v.0.8.0 changed its interface such that it deals entirely with
bytes, which has downstream effects for Python 3, which uses unicode as
the native string type. In 0.8.0, the Tabixfile.fetch method now expects
to receive bytes instead of a (unicode) string for the the "reference"
argument. This is evidenced in a recent rebuild of PyVCF's "master"
since its release:

https://travis-ci.org/gotgenes/PyVCF/jobs/34783332#L1936

pysam is currently wrestling with dealing with unicode and bytes issues
in Python 3: https://github.com/pysam-developers/pysam/issues/29
