### PR TITLE
Bugfix: SNP records with N as ALT now noted as SNPs.

### DIFF
--- a/vcf/model.py
+++ b/vcf/model.py
@@ -376,7 +376,7 @@ class _Record(object):
         for alt in self.ALT:
             if alt is None or alt.type != "SNV":
                 return False
-            if alt not in ['A', 'C', 'G', 'T']:
+            if alt not in ['A', 'C', 'G', 'T', 'N']:
                 return False
         return True
 

--- a/vcf/test/test_vcf.py
+++ b/vcf/test/test_vcf.py
@@ -561,6 +561,24 @@ class TestRecord(unittest.TestCase):
             elif var.POS == 1234567:
                 self.assertEqual(False, is_snp)
 
+
+    def test_is_snp_for_n_alt(self):
+        record = model._Record(
+                '1',
+                10,
+                'id1',
+                'C',
+                [model._Substitution('N')],
+                None,
+                None,
+                {},
+                None,
+                {},
+                None
+        )
+        self.assertTrue(record.is_snp)
+
+
     def test_is_indel(self):
         reader = vcf.Reader(fh('example-4.0.vcf'))
         for var in reader:


### PR DESCRIPTION
The VCF 4.0 and newer specifications say the ALT field is a comma
separated list that includes "base Strings made up of the bases
A,C,G,T,N". Notably, the last case was not handled by `Record.is_snp`,
causing it to erroneously report `False` for records with "N" as the ALT.
