### PR TITLE
Support quoted values in INFO fields

### DIFF
--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -395,8 +395,14 @@ class Reader(object):
                 val = True
             elif entry_type in ('String', 'Character'):
                 try:
-                    vals = entry[1].split(',') # commas are reserved characters indicating multiple values
-                    val = self._map(str, vals)
+                    # support quoted strings (test if string is quoted)
+                    if entry[1][0]+entry[1][-1] in ['""', "''"]:
+                        val = [entry[1]]
+                    else:
+                        # commas are reserved characters indicating
+                        # multiple values
+                        vals = entry[1].split(',')
+                        val = self._map(str, vals)
                 except IndexError:
                     entry_type = 'Flag'
                     val = True
@@ -634,7 +640,9 @@ class Writer(object):
     counts = dict((v,k) for k,v in field_counts.iteritems())
 
     def __init__(self, stream, template, lineterminator="\n"):
-        self.writer = csv.writer(stream, delimiter="\t", lineterminator=lineterminator)
+        self.writer = csv.writer(stream, delimiter="\t",
+                                 lineterminator=lineterminator,
+                                 quotechar='', quoting=csv.QUOTE_NONE)
         self.template = template
         self.stream = stream
 


### PR DESCRIPTION
We had an issue where an INFO field contained a quoted value with spaces and commas. The field was parsed incorrectly, resulting in partial INFO field values. In addition, writing quoted INFO fields resulted in the entire INFO field section being wrapped in quotes (by the csv module). I disabled quoting in the csv writer since it isn't necessary when writing VCF files. I realize this may not be the perfect solution so I'm open to any other ideas on how to fix this.