### PR TITLE
Support ##contig headers with only ID attributes. Generated by bcftools 1.2 when inputs have no ##contig information

### DIFF
--- a/vcf/test/contig_idonly.vcf
+++ b/vcf/test/contig_idonly.vcf
@@ -1,0 +1,5 @@
+##fileformat=VCFv4.2
+##contig=<ID=1>
+##contig=<ID=2,length=2000>
+##contig=<ID=3,assembly=b37,length=3000>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO

--- a/vcf/test/test_vcf.py
+++ b/vcf/test/test_vcf.py
@@ -133,6 +133,17 @@ class TestVcfSpecs(unittest.TestCase):
             for c in r:
                 assert c
 
+    def test_contig_idonly(self):
+        """Test VCF inputs with ##contig inputs containing only IDs. produced by bcftools 1.2+
+        """
+        reader = vcf.Reader(fh("contig_idonly.vcf"))
+        for cid, contig in reader.contigs.items():
+            if cid == "1":
+                assert contig.length is None
+            elif cid == "2":
+                assert contig.length == 2000
+            elif cid == "3":
+                assert contig.length == 3000
 
 class TestGatkOutput(unittest.TestCase):
 


### PR DESCRIPTION
Martijn and all;
The latest version of bcftools/htslib (1.2) add `##contig<ID=chr1>` style tags to VCFs that don't contain `##contig` lines. PyVCF chokes on these as it expects these lines to have `length` key/values as well (which most other tools produce). This supports these lines for input/output. It also adds a unit test for the case. Thanks much.