### PR TITLE
Bump the version to development mode

### DIFF
--- a/vcf/__init__.py
+++ b/vcf/__init__.py
@@ -190,4 +190,4 @@ from vcf.filters import Base as Filter
 from vcf.parser import RESERVED_INFO, RESERVED_FORMAT
 from vcf.sample_filter import SampleFilter
 
-VERSION = '0.6.7'
+VERSION = '0.6.8.dev0'


### PR DESCRIPTION
PyVCF has going through quite a lot of changes in master, however the version is still 0.6.7 in the init.

If we install it directly from the repo we do still have the same version, which confuse a bit everything.

I just bumped to 0.6.8.dev0, but of course any other version number would be good.