### PR TITLE
Change self.data comment. It returns namedtuple not dict

### DIFF
--- a/vcf/model.py
+++ b/vcf/model.py
@@ -20,7 +20,7 @@ class _Call(object):
         self.site = site
         #: The sample name
         self.sample = sample
-        #: Dictionary of data from the VCF file
+        #: Namedtuple of data from the VCF file
         self.data = data
 
         if hasattr(self.data, 'GT'):


### PR DESCRIPTION
I found the docs for vcf.model._Call confusing, because vcf.model._Call.data returns a namedtuple, not a dict. I had to read the code to figure this out.

I'm not sure how your docs are generated, but I'm hoping editing this comment will cause future docs to be generated with the correct data type?


BTW, great package. I've been using it lots!