### PR TITLE
Handle empty columns in Strelka output

### DIFF
--- a/vcf/cparse.pyx
+++ b/vcf/cparse.pyx
@@ -39,7 +39,7 @@ def parse_samples(
             if samp_fmt._fields[j] == 'GT':
                 sampdat[j] = vals
                 continue
-            elif vals == '.':
+            elif not vals or vals == '.':
                 sampdat[j] = None
                 continue
 

--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -273,7 +273,7 @@ class Reader(object):
             self._separator = '\t'
         else:
             self._separator = '\t| +'
-            
+
         self._row_pattern = re.compile(self._separator)
         self._alt_pattern = re.compile('[\[\]]')
 
@@ -466,7 +466,7 @@ class Reader(object):
                 if samp_fmt._fields[i] == 'GT':
                     sampdat[i] = vals
                     continue
-                elif vals == ".":
+                elif not vals or vals == ".":
                     sampdat[i] = None
                     continue
 

--- a/vcf/test/strelka.vcf
+++ b/vcf/test/strelka.vcf
@@ -1,0 +1,57 @@
+##fileformat=VCFv4.1
+##FILTER=<ID=BCNoise,Description="Average fraction of filtered basecalls within 50 bases of the indel exceeds 0.3">
+##FILTER=<ID=QSI_ref,Description="Normal sample is not homozygous ref or sindel Q-score < 30, ie calls with NT!=ref or QSI_NT < 30">
+##FILTER=<ID=QSS_ref,Description="Normal sample is not homozygous ref or ssnv Q-score < 15, ie calls with NT!=ref or QSS_NT < 15">
+##FILTER=<ID=Repeat,Description="Sequence repeat of more than 8x in the reference sequence">
+##FILTER=<ID=SpanDel,Description="Fraction of reads crossing site with spanning deletions in either sample exceeeds 0.75">
+##FILTER=<ID=iHpol,Description="Indel overlaps an interrupted homopolymer longer than 14x in the reference sequence">
+##FORMAT=<ID=AU,Number=2,Type=Integer,Description="Number of 'A' alleles used in tiers 1,2">
+##FORMAT=<ID=CU,Number=2,Type=Integer,Description="Number of 'C' alleles used in tiers 1,2">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read depth for tier1">
+##FORMAT=<ID=DP2,Number=1,Type=Integer,Description="Read depth for tier2">
+##FORMAT=<ID=DP50,Number=1,Type=Float,Description="Average tier1 read depth within 50 bases">
+##FORMAT=<ID=FDP,Number=1,Type=Integer,Description="Number of basecalls filtered from original read depth for tier1">
+##FORMAT=<ID=FDP50,Number=1,Type=Float,Description="Average tier1 number of basecalls filtered from original read depth within 50 bases">
+##FORMAT=<ID=GU,Number=2,Type=Integer,Description="Number of 'G' alleles used in tiers 1,2">
+##FORMAT=<ID=SDP,Number=1,Type=Integer,Description="Number of reads with deletions spanning this site at tier1">
+##FORMAT=<ID=SUBDP,Number=1,Type=Integer,Description="Number of reads below tier1 mapping quality threshold aligned across this site">
+##FORMAT=<ID=SUBDP50,Number=1,Type=Float,Description="Average number of reads below tier1 mapping quality threshold aligned across sites within 50 bases">
+##FORMAT=<ID=TAR,Number=2,Type=Integer,Description="Reads strongly supporting alternate allele for tiers 1,2">
+##FORMAT=<ID=TIR,Number=2,Type=Integer,Description="Reads strongly supporting indel allele for tiers 1,2">
+##FORMAT=<ID=TOR,Number=2,Type=Integer,Description="Other reads (weak support or insufficient indel breakpoint overlap) for tiers 1,2">
+##FORMAT=<ID=TU,Number=2,Type=Integer,Description="Number of 'T' alleles used in tiers 1,2">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency, for each ALT allele, in the same order as listed">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=IC,Number=1,Type=Integer,Description="Number of times RU repeats in the indel allele">
+##INFO=<ID=IHP,Number=1,Type=Integer,Description="Largest reference interrupted homopolymer length intersecting with the indel">
+##INFO=<ID=NT,Number=1,Type=String,Description="Genotype of the normal in all data tiers, as used to classify somatic variants. One of {ref,het,hom,conflict}.">
+##INFO=<ID=OVERLAP,Number=0,Type=Flag,Description="Somatic indel possibly overlaps a second indel.">
+##INFO=<ID=QSI,Number=1,Type=Integer,Description="Quality score for any somatic variant, ie. for the ALT haplotype to be present at a significantly different frequency in the tumor and normal">
+##INFO=<ID=QSI_NT,Number=1,Type=Integer,Description="Quality score reflecting the joint probability of a somatic variant and NT">
+##INFO=<ID=QSS,Number=1,Type=Integer,Description="Quality score for any somatic snv, ie. for the ALT allele to be present at a significantly different frequency in the tumor and normal">
+##INFO=<ID=QSS_NT,Number=1,Type=Integer,Description="Quality score reflecting the joint probability of a somatic variant and NT">
+##INFO=<ID=RC,Number=1,Type=Integer,Description="Number of times RU repeats in the reference allele">
+##INFO=<ID=RU,Number=1,Type=String,Description="Smallest repeating sequence unit in inserted or deleted sequence">
+##INFO=<ID=SGT,Number=1,Type=String,Description="Most likely somatic genotype excluding normal noise states">
+##INFO=<ID=SOMATIC,Number=0,Type=Flag,Description="Somatic mutation">
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##INFO=<ID=TQSI,Number=1,Type=Integer,Description="Data tier used to compute QSI">
+##INFO=<ID=TQSI_NT,Number=1,Type=Integer,Description="Data tier used to compute QSI_NT">
+##INFO=<ID=TQSS,Number=1,Type=Integer,Description="Data tier used to compute QSS">
+##INFO=<ID=TQSS_NT,Number=1,Type=Integer,Description="Data tier used to compute QSS_NT">
+##INFO=<ID=set,Number=1,Type=String,Description="Source VCF for the merged record in CombineVariants">
+##content=strelka somatic indel calls
+##fileDate=20151113
+##germlineIndelTheta=0.0001
+##germlineSnvTheta=0.001
+##priorSomaticIndelRate=1e-06
+##priorSomaticSnvRate=1e-06
+##reference=file:///b37.fasta
+##source=strelka
+##source_version=2.0.17.strelka1
+##startTime=Fri Nov 13 19:38:43 2015
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NORMAL.variant	NORMAL.variant2	TUMOR.variant	TUMOR.variant2
+1	1666175	.	C	T	.	PASS	AC=0;AF=0.00;AN=0;NT=ref;QSS=28;QSS_NT=28;SGT=CC->CT;SOMATIC;TQSS=1;TQSS_NT=1;set=variant	AU:CU:DP:FDP:GU:SDP:SUBDP:TU	0,0:42,42:43:0:0,0:0:0:1,1		0,0:45,45:59:0:0,0:0:0:14,14	
+1	3750492	.	G	A	.	PASS	AC=0;AF=0.00;AN=0;NT=ref;QSS=38;QSS_NT=38;SGT=GG->AG;SOMATIC;TQSS=2;TQSS_NT=2;set=variant	AU:CU:DP:FDP:GU:SDP:SUBDP:TU	0,0:0,0:116:0:116,116:0:0:0,0		6,6:0,0:96:0:90,91:0:0:0,0	
+1	9117626	.	G	A	.	PASS	AC=0;AF=0.00;AN=0;NT=ref;QSS=32;QSS_NT=32;SGT=GG->AG;SOMATIC;TQSS=1;TQSS_NT=1;set=variant	AU:CU:DP:FDP:GU:SDP:SUBDP:TU	0,0:0,0:165:0:165,166:0:0:0,0		6,6:0,0:132:0:126,127:0:0:0,0	

--- a/vcf/test/test_vcf.py
+++ b/vcf/test/test_vcf.py
@@ -231,7 +231,7 @@ class TestBcfToolsOutput(unittest.TestCase):
 
 class TestIssue214(unittest.TestCase):
     """ See https://github.com/jamescasbon/PyVCF/issues/214 """
-    
+
     def test_issue_214_is_snp(self):
         reader=vcf.Reader(fh('issue-214.vcf'))
         r=reader.next()
@@ -257,7 +257,7 @@ class TestIssue214(unittest.TestCase):
         reader.next()
         r=reader.next()
         self.assertEqual(r.var_type,'snp')
-        
+
 class Test1kg(unittest.TestCase):
 
     def testParse(self):
@@ -1553,6 +1553,12 @@ class TestUncalledGenotypes(unittest.TestCase):
         for (in_line, out_line) in zip(in_lines, out_lines):
             self.assertEqual(in_line,out_line)
 
+class TestStrelka(unittest.TestCase):
+
+    def test_strelka(self):
+        reader = vcf.Reader(fh('strelka.vcf'))
+        n = reader.next()
+        assert n is not None
 
 
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestVcfSpecs))
@@ -1585,3 +1591,4 @@ suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestRegression))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestUtils))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestGATKMeta))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestUncalledGenotypes))
+suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestStrelka))


### PR DESCRIPTION
Strelka creates empty columns for imaginary samples and this causes PyVCF to fail in parsing the output (context: https://github.com/hammerlab/cycledash/issues/559). These changes allow empty columns to occur in the VCF and make PyVCF treat them as if they are `.`s. This also includes a test case as a demonstration of the problematic Strelka VCF (note the empty columns, 11 and 13, in the file).