### PR TITLE
Some Travis CI updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 # Validate this file using http://lint.travis-ci.org/
 language: python
+sudo: false
 python:
   - "2.6"
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,11 @@ python:
   - "3.2"
   - "3.3"
   - "3.4"
+  - "3.5"
+  - "nightly"
   - "pypy"
+  - "pypy3"
 install:
-  - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install -r requirements/python2.6-requirements.txt; elif [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then pip install -r requirements/pypy-requirements.txt; else pip install -r requirements/common-requirements.txt; fi"
+  - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install -r requirements/python2.6-requirements.txt; elif [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]] || [[ $TRAVIS_PYTHON_VERSION == 'pypy3' ]]; then pip install -r requirements/pypy-requirements.txt; else pip install -r requirements/common-requirements.txt; fi"
   - python setup.py install
 script: python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 # Validate this file using http://lint.travis-ci.org/
 language: python
 sudo: false
+cache:
+  directories:
+    - $HOME/.cache/pip
 python:
   - "2.6"
   - "2.7"


### PR DESCRIPTION
The containerized builds start and run faster. They also enable caching and they will probably be the default environments at some point, so I'd say we better already move to them.

The pip caching is only used by pip >= 7 (which on Travis only comes with Python 3.5 and up) but I decided not to change the default installed pip version since that is likely to be closer to what people are running in the real world.