### PR TITLE
Fix Travis tests (Pysam installation issues)

### DIFF
--- a/requirements/python2.6-requirements.txt
+++ b/requirements/python2.6-requirements.txt
@@ -1,5 +1,5 @@
--r common-requirements.txt
 argparse
 counter
 ordereddict
+setuptools
 unittest2


### PR DESCRIPTION
Pysam is no longer installable on Python 2.6.
