### PR TITLE
allows info_pattern to match empty values. Fixes #234

### DIFF
--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -83,7 +83,7 @@ class _vcf_metadata_parser(object):
         super(_vcf_metadata_parser, self).__init__()
         self.info_pattern = re.compile(r'''\#\#INFO=<
             ID=(?P<id>[^,]+),\s*
-            Number=(?P<number>(?:(-?\d+|\.|[AGR]))?),\s*
+            Number=(?P<number>-?\d+|\.|[AGR])?,\s*
             Type=(?P<type>Integer|Float|Flag|Character|String),\s*
             Description="(?P<desc>[^"]*)"
             (?:,\s*Source="(?P<source>[^"]*)")?
@@ -112,7 +112,7 @@ class _vcf_metadata_parser(object):
 
     def vcf_field_count(self, num_str):
         """Cast vcf header numbers to integer or None"""
-        if num_str is None or num_str == "":
+        if num_str is None:
             return None
         elif num_str not in field_counts:
             # Fixed, specified number

--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -83,7 +83,7 @@ class _vcf_metadata_parser(object):
         super(_vcf_metadata_parser, self).__init__()
         self.info_pattern = re.compile(r'''\#\#INFO=<
             ID=(?P<id>[^,]+),\s*
-            Number=(?P<number>-?\d+|\.|[AGR]),\s*
+            Number=(?P<number>(?:(-?\d+|\.|[AGR]))?),\s*
             Type=(?P<type>Integer|Float|Flag|Character|String),\s*
             Description="(?P<desc>[^"]*)"
             (?:,\s*Source="(?P<source>[^"]*)")?
@@ -112,7 +112,7 @@ class _vcf_metadata_parser(object):
 
     def vcf_field_count(self, num_str):
         """Cast vcf header numbers to integer or None"""
-        if num_str is None:
+        if num_str is None or num_str == "":
             return None
         elif num_str not in field_counts:
             # Fixed, specified number

--- a/vcf/test/test_vcf.py
+++ b/vcf/test/test_vcf.py
@@ -1271,6 +1271,22 @@ class TestIssue201(unittest.TestCase):
             pass
 
 
+class TestIssue234(unittest.TestCase):
+    """ See https://github.com/jamescasbon/PyVCF/issues/234 """
+
+    def test_vcf_metadata_parser_doesnt_break_with_empty_number_tags(self):
+        parser = vcf.parser._vcf_metadata_parser()
+        num_str = '##INFO=<ID=CA,Number=,Type=Flag,Description="Position '
+        num_str += 'could not be annotated to a coding region of a transcript '
+        num_str += 'using the supplied bed file">'
+        try:
+            parser.read_info(num_str)
+        except SyntaxError:
+            msg = "vcf.parser._vcf_metadata_parser shouldn't raise SyntaxError"
+            msg += " if Number tag is empty."
+            self.fail(msg)
+
+
 class TestOpenMethods(unittest.TestCase):
 
     samples = 'NA00001 NA00002 NA00003'.split()
@@ -1584,6 +1600,7 @@ suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestRecord))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestCall))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestFetch))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestIssue201))
+suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestIssue234))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestOpenMethods))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestSampleFilter))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestFilter))

--- a/vcf/test/test_vcf.py
+++ b/vcf/test/test_vcf.py
@@ -1280,7 +1280,8 @@ class TestIssue234(unittest.TestCase):
         num_str += 'could not be annotated to a coding region of a transcript '
         num_str += 'using the supplied bed file">'
         try:
-            parser.read_info(num_str)
+            info = parser.read_info(num_str)[1]
+            self.assertIsNone(info.num)
         except SyntaxError:
             msg = "vcf.parser._vcf_metadata_parser shouldn't raise SyntaxError"
             msg += " if Number tag is empty."


### PR DESCRIPTION
Regards,

On Issue #234 I described an error when reading INFO tags. This pull request allows the `info_pattern` regex to match empty values. It now works for my vcf files and perhaps you may want to marge the changes. 

Let me know if you have any questions.