### PR TITLE
Is filt

### DIFF
--- a/vcf/cparse.pyx
+++ b/vcf/cparse.pyx
@@ -9,6 +9,19 @@ INTEGER = 'Integer'
 FLOAT = 'Float'
 NUMERIC = 'Numeric'
 
+def _parse_filter(filt_str):
+    '''Parse the FILTER field of a VCF entry into a Python list
+
+    NOTE: this method has a python equivalent and care must be taken
+    to keep the two methods equivalent
+    '''
+    if filt_str == '.':
+        return None
+    elif filt_str == 'PASS':
+        return []
+    else:
+        return filt_str.split(';')
+
 def parse_samples(
         list names, list samples, samp_fmt,
         list samp_fmt_types, list samp_fmt_nums, site):
@@ -38,6 +51,10 @@ def parse_samples(
             # short circuit the most common
             if samp_fmt._fields[j] == 'GT':
                 sampdat[j] = vals
+                continue
+            # genotype filters are a special case
+            elif samp_fmt._fields[j] == 'FT':
+                sampdat[j] = _parse_filter(vals)
                 continue
             elif not vals or vals == '.':
                 sampdat[j] = None

--- a/vcf/model.py
+++ b/vcf/model.py
@@ -118,20 +118,16 @@ class _Call(object):
         return self.gt_type == 1
 
     @property
-    def is_filt(self):
+    def is_filtered(self):
         """ Return True for filtered calls """
         try: # no FT annotation present for this variant
-            FT=self.data.FT
+            filt = self.data.FT
         except AttributeError:
             return False
-        if FT == None or FT == []: # FT is not set or set to PASS
+        if filt is None or len(filt) == 0: # FT is not set or set to PASS
             return False
-        elif len(FT) > 0: # FT contains one or more filters
+        else:
             return True
-        else: # This should not happen
-            raise RuntimeError(
-                "Parsing error for FT annotation in {}, "\
-                "please file a bug".format(self))
 
 
 class _Record(object):
@@ -553,17 +549,13 @@ class _Record(object):
         return len(self.ALT) == 1 and self.ALT[0] is None
 
     @property
-    def is_filt(self,call=None):
+    def is_filtered(self):
         """ Return True if a variant has been filtered """
-        FT=self.FILTER
-        if FT == None or FT == []: # FT is not set or set to PASS
+        filt = self.FILTER
+        if filt is None or len(filt) == 0: # FILTER is not set or set to PASS
             return False
-        elif len(FT) > 0: # FT contains one or more filters
+        else:
             return True
-        else: # This should not happen
-            raise RuntimeError(
-                "Parsing error for FILTER annotation in {}, "\
-                "please file a bug".format(self))
 
 
 class _AltRecord(object):

--- a/vcf/model.py
+++ b/vcf/model.py
@@ -117,6 +117,22 @@ class _Call(object):
             return None
         return self.gt_type == 1
 
+    @property
+    def is_filt(self):
+        """ Return True for filtered calls """
+        try: # no FT annotation present for this variant
+            FT=self.data.FT
+        except AttributeError:
+            return False
+        if FT == None or FT == []: # FT is not set or set to PASS
+            return False
+        elif len(FT) > 0: # FT contains one or more filters
+            return True
+        else: # This should not happen
+            raise RuntimeError(
+                "Parsing error for FT annotation in {}, "\
+                "please file a bug".format(self))
+
 
 class _Record(object):
     """ A set of calls at a site.  Equivalent to a row in a VCF file.
@@ -535,6 +551,19 @@ class _Record(object):
     def is_monomorphic(self):
         """ Return True for reference calls """
         return len(self.ALT) == 1 and self.ALT[0] is None
+
+    @property
+    def is_filt(self,call=None):
+        """ Return True if a variant has been filtered """
+        FT=self.FILTER
+        if FT == None or FT == []: # FT is not set or set to PASS
+            return False
+        elif len(FT) > 0: # FT contains one or more filters
+            return True
+        else: # This should not happen
+            raise RuntimeError(
+                "Parsing error for FILTER annotation in {}, "\
+                "please file a bug".format(self))
 
 
 class _AltRecord(object):

--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -359,6 +359,15 @@ class Reader(object):
         return [func(x) if x != bad else None
                 for x in iterable]
 
+    def _parse_filter(self, filt_str):
+        '''Parse the FILTER field of a VCF entry into a Python list'''
+        if filt_str == '.':
+            return None
+        elif filt_str == 'PASS':
+            return []
+        else:
+            return filt_str.split(';')
+
     def _parse_info(self, info_str):
         '''Parse the INFO field of a VCF entry into a dictionary of Python
         types.
@@ -562,13 +571,7 @@ class Reader(object):
             except ValueError:
                 qual = None
 
-        filt = row[6]
-        if filt == '.':
-            filt = None
-        elif filt == 'PASS':
-            filt = []
-        else:
-            filt = filt.split(';')
+        filt = self._parse_filter(row[6])
         info = self._parse_info(row[7])
 
         try:

--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -360,7 +360,11 @@ class Reader(object):
                 for x in iterable]
 
     def _parse_filter(self, filt_str):
-        '''Parse the FILTER field of a VCF entry into a Python list'''
+        '''Parse the FILTER field of a VCF entry into a Python list
+
+        NOTE: this method has a cython equivalent and care must be taken
+        to keep the two methods equivalent
+        '''
         if filt_str == '.':
             return None
         elif filt_str == 'PASS':
@@ -474,6 +478,10 @@ class Reader(object):
                 # short circuit the most common
                 if samp_fmt._fields[i] == 'GT':
                     sampdat[i] = vals
+                    continue
+                # genotype filters are a special case
+                elif samp_fmt._fields[i] == 'FT':
+                    sampdat[i] = self._parse_filter(vals)
                     continue
                 elif not vals or vals == ".":
                     sampdat[i] = None

--- a/vcf/test/FT.vcf
+++ b/vcf/test/FT.vcf
@@ -1,0 +1,50 @@
+##fileformat=VCFv4.2
+##ALT=<ID=NON_REF,Description="Represents any possible alternative allele at this location">
+##FILTER=<ID=DP125,Description="DP<125">
+##FILTER=<ID=DP130,Description="DP<130">
+##FILTER=<ID=LowQual,Description="Low quality">
+##FILTER=<ID=Q4800,Description="QUAL<4800.0">
+##FILTER=<ID=Q5000,Description="QUAL<5000.0">
+##FORMAT=<ID=AD,Number=R,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth (reads with MQ=255 or with bad mates are filtered)">
+##FORMAT=<ID=FT,Number=.,Type=String,Description="Genotype-level filter">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=MIN_DP,Number=1,Type=Integer,Description="Minimum DP observed within the GVCF block">
+##FORMAT=<ID=PL,Number=G,Type=Integer,Description="Normalized, Phred-scaled likelihoods for genotypes as defined in the VCF specification">
+##FORMAT=<ID=RGQ,Number=1,Type=Integer,Description="Unconditional reference genotype confidence, encoded as a phred quality -10*log10 p(genotype call is wrong)">
+##FORMAT=<ID=SB,Number=4,Type=Integer,Description="Per-sample component statistics which comprise the Fisher's Exact Test to detect strand bias.">
+##GATKCommandLine.VariantFiltration=<ID=VariantFiltration,Version=3.6-0-g89b7209,Date="Wed Jul 27 09:50:44 CEST 2016",Epoch=1469605844963,CommandLineOptions="analysis_type=VariantFiltration input_file=[] showFullBamList=false read_buffer_size=null read_filter=[] disable_read_filter=[] intervals=null excludeIntervals=null interval_set_rule=UNION interval_merging=ALL interval_padding=0 reference_sequence=../ref.fasta nonDeterministicRandomSeed=false disableDithering=false maxRuntime=-1 maxRuntimeUnits=MINUTES downsampling_type=BY_SAMPLE downsample_to_fraction=null downsample_to_coverage=1000 baq=OFF baqGapOpenPenalty=40.0 refactor_NDN_cigar_string=false fix_misencoded_quality_scores=false allow_potentially_misencoded_quality_scores=false useOriginalQualities=false defaultBaseQualities=-1 performanceLog=null BQSR=null quantize_quals=0 static_quantized_quals=null round_down_quantized=false disable_indel_quals=false emit_original_quals=false preserve_qscores_less_than=6 globalQScorePrior=-1.0 validation_strictness=SILENT remove_program_records=false keep_program_records=false sample_rename_mapping_file=null unsafe=null disable_auto_index_creation_and_locking_when_reading_rods=false no_cmdline_in_header=false sites_only=false never_trim_vcf_format_field=false bcf=false bam_compression=null simplifyBAM=false disable_bam_indexing=false generate_md5=false num_threads=1 num_cpu_threads_per_data_thread=1 num_io_threads=0 monitorThreadEfficiency=false num_bam_file_handles=null read_group_black_list=null pedigree=[] pedigreeString=[] pedigreeValidationType=STRICT allow_intervals_with_unindexed_bam=false generateShadowBCF=false variant_index_type=DYNAMIC_SEEK variant_index_parameter=-1 reference_window_stop=0 phone_home= gatk_key=null tag=NA logging_level=INFO log_to_file=null help=false version=false variant=(RodBinding name=variant source=10.vcf) mask=(RodBinding name= source=UNBOUND) out=/home/redmar/tmp/example/snps/10_filt.vcf filterExpression=[QUAL<5000.0, QUAL<4800.0] filterName=[Q5000, Q4800] genotypeFilterExpression=[DP<130, DP<125] genotypeFilterName=[DP130, DP125] clusterSize=3 clusterWindowSize=0 maskExtension=0 maskName=Mask filterNotInMask=false missingValuesInExpressionsShouldEvaluateAsFailing=false invalidatePreviousFilters=false invertFilterExpression=false invertGenotypeFilterExpression=false setFilteredGtToNocall=false filter_reads_with_N_cigar=false filter_mismatching_base_and_quals=false filter_bases_not_stored=false">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency, for each ALT allele, in the same order as listed">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=BaseQRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt Vs. Ref base qualities">
+##INFO=<ID=ClippingRankSum,Number=1,Type=Float,Description="Z-score From Wilcoxon rank sum test of Alt vs. Ref number of hard clipped bases">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth; some reads may have been filtered">
+##INFO=<ID=DS,Number=0,Type=Flag,Description="Were any of the samples downsampled?">
+##INFO=<ID=END,Number=1,Type=Integer,Description="Stop position of the interval">
+##INFO=<ID=ExcessHet,Number=1,Type=Float,Description="Phred-scaled p-value for exact test of excess heterozygosity">
+##INFO=<ID=FS,Number=1,Type=Float,Description="Phred-scaled p-value using Fisher's exact test to detect strand bias">
+##INFO=<ID=HaplotypeScore,Number=1,Type=Float,Description="Consistency of the site with at most two segregating haplotypes">
+##INFO=<ID=InbreedingCoeff,Number=1,Type=Float,Description="Inbreeding coefficient as estimated from the genotype likelihoods per-sample when compared against the Hardy-Weinberg expectation">
+##INFO=<ID=MLEAC,Number=A,Type=Integer,Description="Maximum likelihood expectation (MLE) for the allele counts (not necessarily the same as the AC), for each ALT allele, in the same order as listed">
+##INFO=<ID=MLEAF,Number=A,Type=Float,Description="Maximum likelihood expectation (MLE) for the allele frequency (not necessarily the same as the AF), for each ALT allele, in the same order as listed">
+##INFO=<ID=MQ,Number=1,Type=Float,Description="RMS Mapping Quality">
+##INFO=<ID=MQRankSum,Number=1,Type=Float,Description="Z-score From Wilcoxon rank sum test of Alt vs. Ref read mapping qualities">
+##INFO=<ID=QD,Number=1,Type=Float,Description="Variant Confidence/Quality by Depth">
+##INFO=<ID=RAW_MQ,Number=1,Type=Float,Description="Raw data for RMS Mapping Quality">
+##INFO=<ID=ReadPosRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt vs. Ref read position bias">
+##INFO=<ID=SOR,Number=1,Type=Float,Description="Symmetric Odds Ratio of 2x2 contingency table to detect strand bias">
+##contig=<ID=ref,length=4888768>
+##reference=file://../ref.fasta
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	1	2	3	4	5
+ref	63393	.	C	A	29454.60	.	AC=5;AF=1.00;AN=5;DP=719;FS=0.000;MLEAC=5;MLEAF=1.00;MQ=60.00;QD=29.67;SOR=0.965	GT:AD:DP:GQ:PL	1:0,166:166:99:6740,0	1:0,142:142:99:5824,0	1:0,134:134:99:5616,0	1:0,122:122:99:4930,0	1:0,155:155:99:6371,0
+ref	65903	.	AATTGCGCTG	A	7340.57	PASS	AC=1;AF=0.200;AN=5;DP=524;FS=0.000;MLEAC=1;MLEAF=0.200;MQ=60.00;QD=34.04;SOR=1.091	GT:AD:DP:FT:GQ:PL	1:0,164:164:PASS:99:7383,0	0:95,0:95:DP125;DP130:99:0,1800	0:88,0:88:DP125;DP130:99:0,1800	0:87,0:87:DP125;DP130:99:0,1800	0:89,0:89:DP125;DP130:99:0,1800
+ref	70837	.	C	A	4711.61	Q4800;Q5000	AC=1;AF=0.200;AN=5;DP=512;FS=0.000;MLEAC=1;MLEAF=0.200;MQ=60.00;QD=27.64;SOR=0.726	GT:AD:DP:FT:GQ:PL	0:121,0:121:DP125;DP130:99:0,1800	0:95,0:95:DP125;DP130:99:0,1800	1:0,120:120:DP125;DP130:99:4745,0	0:87,0:87:DP125;DP130:99:0,1800	0:89,0:89:DP125;DP130:99:0,1800
+ref	71448	.	C	T	31134.60	PASS	AC=5;AF=1.00;AN=5;BaseQRankSum=2.22;ClippingRankSum=0.00;DP=768;FS=0.000;MLEAC=5;MLEAF=1.00;MQ=60.00;MQRankSum=0.00;QD=29.43;ReadPosRankSum=2.03;SOR=0.295	GT:AD:DP:FT:GQ:PL	1:0,147:147:PASS:99:5996,0	1:1,183:184:PASS:99:7501,0	1:0,113:113:DP125;DP130:99:4559,0	1:0,161:161:PASS:99:6436,0	1:0,163:163:PASS:99:6669,0
+ref	104257	.	C	T	5521.61	PASS	AC=1;AF=0.200;AN=5;DP=506;FS=0.000;MLEAC=1;MLEAF=0.200;MQ=60.00;QD=29.45;SOR=0.854	GT:AD:DP:FT:GQ:PL	0:101,0:101:DP125;DP130:99:0,1800	0:109,0:109:DP125;DP130:99:0,1800	1:0,132:132:PASS:99:5555,0	0:67,0:67:DP125;DP130:99:0,1800	0:97,0:97:DP125;DP130:99:0,1800
+ref	140658	.	C	A	32467.60	PASS	AC=5;AF=1.00;AN=5;BaseQRankSum=2.24;ClippingRankSum=0.00;DP=801;FS=0.000;MLEAC=5;MLEAF=1.00;MQ=60.00;MQRankSum=0.00;QD=29.65;ReadPosRankSum=1.27;SOR=0.346	GT:AD:DP:GQ:PL	1:0,170:170:99:6854,0	1:0,198:198:99:8098,0	1:0,136:136:99:5554,0	1:0,141:141:99:5661,0	1:1,155:156:99:6327,0
+ref	147463	.	C	A	4885.61	Q5000	AC=1;AF=0.200;AN=5;BaseQRankSum=-7.720e-01;ClippingRankSum=0.00;DP=503;FS=0.000;MLEAC=1;MLEAF=0.200;MQ=60.00;MQRankSum=0.00;QD=35.03;ReadPosRankSum=-6.950e-01;SOR=0.278	GT:AD:DP:FT:GQ:PL	0:97,0:97:DP125;DP130:99:0,1800	0:104,0:104:DP125;DP130:99:0,1800	0:84,0:84:DP125;DP130:99:0,1800	1:1,128:129:DP130:99:4919,0	0:89,0:89:DP125;DP130:99:0,1800
+ref	154578	.	A	G	32015.60	PASS	AC=5;AF=1.00;AN=5;DP=776;FS=0.000;MLEAC=5;MLEAF=1.00;MQ=60.00;QD=25.82;SOR=0.902	GT:AD:DP:GQ:PL	1:0,152:152:99:6300,0	1:0,183:183:99:7608,0	1:0,137:137:99:5713,0	1:0,148:148:99:6040,0	1:0,156:156:99:6381,0
+ref	203200	.	C	T	30880.60	PASS	AC=5;AF=1.00;AN=5;DP=752;FS=0.000;MLEAC=5;MLEAF=1.00;MQ=60.00;QD=29.65;SOR=0.878	GT:AD:DP:FT:GQ:PL	1:0,161:161:PASS:99:6708,0	1:0,185:185:PASS:99:7602,0	1:0,136:136:PASS:99:5602,0	1:0,126:126:DP130:99:5080,0	1:0,144:144:PASS:99:5915,0
+ref	231665	.	C	T	30074.60	PASS	AC=5;AF=1.00;AN=5;DP=735;FS=0.000;MLEAC=5;MLEAF=1.00;MQ=60.00;QD=33.23;SOR=0.938	GT:AD:DP:FT:GQ:PL	1:0,191:191:PASS:99:7867,0	1:0,159:159:PASS:99:6431,0	1:0,130:130:PASS:99:5299,0	1:0,129:129:DP130:99:5290,0	1:0,126:126:DP130:99:5214,0

--- a/vcf/test/test_vcf.py
+++ b/vcf/test/test_vcf.py
@@ -1319,8 +1319,8 @@ class TestIssue246(unittest.TestCase):
         self.assertEqual(target,result)
             
 
-class TestIsFilt(unittest.TestCase):
-    """ Test is_filt property for _Call and _Record """
+class TestIsFiltered(unittest.TestCase):
+    """ Test is_filtered property for _Call and _Record """
 
     def test_is_filt_record(self):
         reader = vcf.Reader(fh('FT.vcf'))
@@ -1328,14 +1328,14 @@ class TestIsFilt(unittest.TestCase):
             False, False, True, False, False,
             False, True, False, False, False
         ]
-        result = [record.is_filt for record in reader]
+        result = [record.is_filtered for record in reader]
         self.assertEqual(target,result)
 
     def test_is_filt_call_unset(self):
         reader = vcf.Reader(fh('FT.vcf'))
         record = next(reader)
         target = [False]*5
-        result = [call.is_filt for call in record]
+        result = [call.is_filtered for call in record]
         self.assertEqual(target,result)
 
     def test_is_filt_call_pass_two(self):
@@ -1343,14 +1343,14 @@ class TestIsFilt(unittest.TestCase):
         next(reader)
         record = next(reader)
         target = [False, True, True, True, True]
-        result = [call.is_filt for call in record]
+        result = [call.is_filtered for call in record]
         self.assertEqual(target,result)
 
     def test_is_filt_call_one(self):
         reader = list(vcf.Reader(fh('FT.vcf')))
         record = reader[6]
         target = [True]*5
-        result = [call.is_filt for call in record]
+        result = [call.is_filtered for call in record]
         self.assertEqual(target,result)
 
 
@@ -1669,7 +1669,7 @@ suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestFetch))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestIssue201))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestIssue234))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestIssue246))
-suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestIsFilt))
+suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestIsFiltered))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestOpenMethods))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestSampleFilter))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestFilter))

--- a/vcf/test/test_vcf.py
+++ b/vcf/test/test_vcf.py
@@ -1319,6 +1319,41 @@ class TestIssue246(unittest.TestCase):
         self.assertEqual(target,result)
             
 
+class TestIsFilt(unittest.TestCase):
+    """ Test is_filt property for _Call and _Record """
+
+    def test_is_filt_record(self):
+        reader = vcf.Reader(fh('FT.vcf'))
+        target = [
+            False, False, True, False, False,
+            False, True, False, False, False
+        ]
+        result = [record.is_filt for record in reader]
+        self.assertEqual(target,result)
+
+    def test_is_filt_call_unset(self):
+        reader = vcf.Reader(fh('FT.vcf'))
+        record = next(reader)
+        target = [False]*5
+        result = [call.is_filt for call in record]
+        self.assertEqual(target,result)
+
+    def test_is_filt_call_pass_two(self):
+        reader = vcf.Reader(fh('FT.vcf'))
+        next(reader)
+        record = next(reader)
+        target = [False, True, True, True, True]
+        result = [call.is_filt for call in record]
+        self.assertEqual(target,result)
+
+    def test_is_filt_call_one(self):
+        reader = list(vcf.Reader(fh('FT.vcf')))
+        record = reader[6]
+        target = [True]*5
+        result = [call.is_filt for call in record]
+        self.assertEqual(target,result)
+
+
 class TestOpenMethods(unittest.TestCase):
 
     samples = 'NA00001 NA00002 NA00003'.split()
@@ -1634,6 +1669,7 @@ suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestFetch))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestIssue201))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestIssue234))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestIssue246))
+suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestIsFilt))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestOpenMethods))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestSampleFilter))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestFilter))

--- a/vcf/test/test_vcf.py
+++ b/vcf/test/test_vcf.py
@@ -1288,6 +1288,37 @@ class TestIssue234(unittest.TestCase):
             self.fail(msg)
 
 
+class TestIssue246(unittest.TestCase):
+    """ See https://github.com/jamescasbon/PyVCF/issues/246 """
+
+    def test_FT_pass_two(self):
+        reader=vcf.Reader(fh('FT.vcf'))
+        next(reader)
+        r=next(reader)
+        target=[
+            [],
+            ['DP125','DP130'],
+            ['DP125','DP130'],
+            ['DP125','DP130'],
+            ['DP125','DP130']
+        ]
+        result=[call.data.FT for call in r.samples]
+        self.assertEqual(target,result)
+
+    def test_FT_one_two(self):
+        reader=list(vcf.Reader(fh('FT.vcf')))
+        r=reader[6]
+        target=[
+            ['DP125','DP130'],
+            ['DP125','DP130'],
+            ['DP125','DP130'],
+            ['DP130'],
+            ['DP125','DP130']
+        ]
+        result=[call.data.FT for call in r.samples]
+        self.assertEqual(target,result)
+            
+
 class TestOpenMethods(unittest.TestCase):
 
     samples = 'NA00001 NA00002 NA00003'.split()
@@ -1602,6 +1633,7 @@ suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestCall))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestFetch))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestIssue201))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestIssue234))
+suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestIssue246))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestOpenMethods))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestSampleFilter))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestFilter))


### PR DESCRIPTION
I have implemented the convenience property is_filt for both _Record and _Call, to indicate whether a variant or single call has been filtered. 

I often work with filtered vcf files, and so I found myself writing a bit of code to check whether a call or variant had been filtered. Like is_snp or is_indel, I figured is_filt would be useful to have in PyVCF itself.