### PR TITLE
Always use a list for list-type fields

### DIFF
--- a/vcf/cparse.pyx
+++ b/vcf/cparse.pyx
@@ -65,8 +65,7 @@ def parse_samples(
             entry_num = samp_fmt_nums[j]
 
             # we don't need to split single entries
-            if entry_num == 1 or ',' not in vals:
-
+            if entry_num == 1:
                 if entry_type == INTEGER:
                     try:
                         sampdat[j] = int(vals)
@@ -76,14 +75,9 @@ def parse_samples(
                     sampdat[j] = float(vals)
                 else:
                     sampdat[j] = vals
-
-                if entry_num != 1:
-                    sampdat[j] = (sampdat[j])
-
                 continue
 
             vals = vals.split(',')
-
             if entry_type == INTEGER:
                 try:
                     sampdat[j] = _map(int, vals)

--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -491,8 +491,7 @@ class Reader(object):
                 entry_type = samp_fmt._types[i]
 
                 # we don't need to split single entries
-                if entry_num == 1 or ',' not in vals:
-
+                if entry_num == 1:
                     if entry_type == 'Integer':
                         try:
                             sampdat[i] = int(vals)
@@ -502,14 +501,9 @@ class Reader(object):
                         sampdat[i] = float(vals)
                     else:
                         sampdat[i] = vals
-
-                    if entry_num != 1:
-                        sampdat[i] = (sampdat[i])
-
                     continue
 
                 vals = vals.split(',')
-
                 if entry_type == 'Integer':
                     try:
                         sampdat[i] = _map(int, vals)

--- a/vcf/test/issue-254.vcf
+++ b/vcf/test/issue-254.vcf
@@ -1,0 +1,9 @@
+##fileformat=VCFv4.1
+##fileDate=20090805
+##source=myImputationProgramV3.1
+##reference=1000GenomesPilot-NCBI36
+##phasing=partial
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=AO,Number=A,Type=Integer,Description="Alternate allele observation count">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA00001	NA00002	NA00003
+21	4242421	.	T	A	30	.	.	GT:AO	0|0:0.1	0|1:0.2	0/0:0.3

--- a/vcf/test/test_vcf.py
+++ b/vcf/test/test_vcf.py
@@ -1353,6 +1353,17 @@ class TestIssue246(unittest.TestCase):
         self.assertEqual(target,result)
 
 
+class TestIssue254(unittest.TestCase):
+    """ See https://github.com/jamescasbon/PyVCF/issues/254 """
+
+    def test_remains_singleton_list(self):
+        reader = vcf.Reader(fh('issue-254.vcf'))
+        record = next(reader)
+        expected = [[0.1], [0.2], [0.3]]
+        actual = [call.data.AO for call in record.samples]
+        self.assertEqual(expected, actual)
+
+
 class TestIsFiltered(unittest.TestCase):
     """ Test is_filtered property for _Call and _Record """
 
@@ -1703,6 +1714,7 @@ suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestFetch))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestIssue201))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestIssue234))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestIssue246))
+suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestIssue254))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestIsFiltered))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestOpenMethods))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestSampleFilter))


### PR DESCRIPTION
Singleton lists - e.g. `Number=A` with a single allele - are now parsed
into lists instead of being treated as single values. This is more
consistent with the meaning of the field definition and thus easier
for client code.

Fixes #254.

I didn't know the right place to put the test for this, or if this is
really a sufficient test. I made the same change in the Cython
parser.

The existing code intended to re-listify the singleton value but used
parentheses instead of brackets. It seems more logical and potentially
faster to eliminate the extra comparison and branch and treat list
types. I don't notice any change in the performance test, but the
noise is high.