### PR TITLE
Unify code paths' treatment of "Numeric" type

### DIFF
--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -498,7 +498,7 @@ class Reader(object):
                             sampdat[i] = int(vals)
                         except ValueError:
                             sampdat[i] = float(vals)
-                    elif entry_type == 'Float':
+                    elif entry_type == 'Float' or entry_type == 'Numeric':
                         sampdat[i] = float(vals)
                     else:
                         sampdat[i] = vals


### PR DESCRIPTION
This appears to only exist for legacy compatibility, but I noticed the
single-value path in the Python parser was not the same as the
list-type path (it doesn't know about "Numeric"). The Cython parser
treats both equally already.