### PR TITLE
Performance improvements

### DIFF
--- a/vcf/cparse.pyx
+++ b/vcf/cparse.pyx
@@ -1,15 +1,16 @@
 from model import _Call
 
-cdef _map(func, iterable, bad=['.', '']):
+cdef int INTEGER = 0
+cdef int STRING = 1
+cdef int FLOAT = 2
+cdef int FLAG = 3
+
+cdef list _map(func, iterable, bad=['.', '']):
     '''``map``, but make bad values None.'''
     return [func(x) if x not in bad else None
             for x in iterable]
 
-INTEGER = 'Integer'
-FLOAT = 'Float'
-NUMERIC = 'Numeric'
-
-def _parse_filter(filt_str):
+cdef _parse_filter(str filt_str):
     '''Parse the FILTER field of a VCF entry into a Python list
 
     NOTE: this method has a python equivalent and care must be taken
@@ -26,10 +27,12 @@ def parse_samples(
         list names, list samples, samp_fmt,
         list samp_fmt_types, list samp_fmt_nums, site):
 
-    cdef char *name, *fmt, *entry_type, *sample
+    cdef char *name
+    cdef char *fmt
+    cdef char *sample
+    cdef int entry_type
     cdef int i, j
     cdef list samp_data = []
-    cdef dict sampdict
     cdef list sampvals
     n_samples = len(samples)
     n_formats = len(samp_fmt._fields)
@@ -71,7 +74,7 @@ def parse_samples(
                         sampdat[j] = int(vals)
                     except ValueError:
                         sampdat[j] = float(vals)
-                elif entry_type == FLOAT or entry_type == NUMERIC:
+                elif entry_type == FLOAT:
                     sampdat[j] = float(vals)
                 else:
                     sampdat[j] = vals
@@ -82,8 +85,8 @@ def parse_samples(
                 try:
                     sampdat[j] = _map(int, vals)
                 except ValueError:
-                    sampdat[j] = map(float, vals)
-            elif entry_type == FLOAT or entry_type == NUMERIC:
+                    sampdat[j] = _map(float, vals)
+            elif entry_type == FLOAT:
                 sampdat[j] = _map(float, vals)
             else:
                 sampdat[j] = vals

--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -594,7 +594,10 @@ class Reader(object):
                 qual = None
 
         filt = self._parse_filter(row[6])
-        info = self._parse_info(row[7])
+        if cparse is not None:
+            info = cparse.parse_info(row[7], self.infos, RESERVED_INFO_CODES)
+        else:
+            info = self._parse_info(row[7])
 
         try:
             fmt = row[8]

--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -755,6 +755,9 @@ class Writer(object):
         return self._stringify(flt, none='.', delim=';')
 
     def _format_info(self, info):
+        if cparse:
+            return cparse.format_info(info, self.info_order)
+
         if not info:
             return '.'
         def order_key(field):
@@ -764,6 +767,9 @@ class Writer(object):
                         sorted(info, key=order_key))
 
     def _format_sample(self, fmt, sample):
+        if cparse:
+            return cparse.format_sample(fmt, sample)
+
         if hasattr(sample.data, 'GT'):
             gt = sample.data.GT
         else:
@@ -772,7 +778,7 @@ class Writer(object):
         result = [gt] if gt else []
         # Following the VCF spec, GT is always the first item whenever it is present.
         for field in sample.data._fields:
-            value = getattr(sample.data,field)
+            value = getattr(sample.data, field)
             if field == 'GT':
                 continue
             if field == 'FT':

--- a/vcf/test/prof.py
+++ b/vcf/test/prof.py
@@ -3,10 +3,14 @@ import cProfile
 import timeit
 import pstats
 import sys
+import os
 
 def parse_1kg():
-    for line in vcf.Reader(filename='vcf/test/1kg.vcf.gz'):
-        pass
+    in_vcf = vcf.Reader(filename='vcf/test/1kg.vcf.gz')
+    with open(os.devnull, "w") as fh:
+        out_vcf = vcf.Writer(fh, template=in_vcf)
+        for line in in_vcf:
+            out_vcf.write_record(line)
 
 if len(sys.argv) == 1:
     sys.argv.append(None)
@@ -29,5 +33,7 @@ elif sys.argv[1] == 'stat':
     finally:
         statprof.stop()
         statprof.display()
+elif sys.argv[1] == 'run':
+    parse_1kg()
 else:
     print 'prof.py profile/time'


### PR DESCRIPTION
I haven't looked at this branch for a few weeks, and you should bear in mind that I've never used Cython before. I've rebased it and it passes all current tests.

My observation was that PyVCF is still rather slow in reading & writing large, real-world VCFs (about 6-8x slower than a simplistic split-index-join approach). The individual commits here should be reasonably clear, and I found:

- integer instead of string comparisons were worth about 5-10% in both Python and Cython implementations
- INFO parsing became the bottleneck, and a very naive Cython version made about 25% difference
- formatting strings for writing was also slow, and a very naive Cython version made about 20% difference

I haven't had much luck with line-profiling to improve things further. One idea might be to lazy-parse the INFO fields – keep them as strings until accessed. They still seem to be a bottleneck even with Cython (large real-world VCFs may contain many annotations, for example).

Downside here is further duplication between Python and Cython, but that seems unavoidable if supporting pure Python remains a priority.