### PR TITLE
expose model.Record

### DIFF
--- a/vcf/__init__.py
+++ b/vcf/__init__.py
@@ -7,9 +7,10 @@ Online version of PyVCF documentation is available at http://pyvcf.rtfd.org/
 
 
 from vcf.parser import Reader, Writer
+from vcf.model import _Record as Record
 from vcf.parser import VCFReader, VCFWriter
 from vcf.filters import Base as Filter
 from vcf.parser import RESERVED_INFO, RESERVED_FORMAT
 from vcf.sample_filter import SampleFilter
 
-VERSION = '0.6.8'
+VERSION = '0.6.9'


### PR DESCRIPTION
This allows for nice things like type annotations for functions that accept a `Record` as well as users building dummy `Record` objects for testing.

For example I can now do this in pycharm and I get auto-completion on the members of Record.

```python
import vcf


def my_record_func(record: vcf.Record):
    """
    :param record: A Record object
    :return: bool
    """
    return 'C' in record.ALT

```