### PR TITLE
VCFReader uses encoding even if uncompressed

### DIFF
--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -266,8 +266,8 @@ class Reader(object):
         self.filename = filename
         if compressed:
             self._reader = gzip.GzipFile(fileobj=self._reader)
-            if sys.version > '3':
-                self._reader = codecs.getreader(encoding)(self._reader)
+        if sys.version > '3':
+            self._reader = codecs.getreader(encoding)(self._reader)
 
         if strict_whitespace:
             self._separator = '\t'


### PR DESCRIPTION
VCF uses encodings only if compressed (gzip).

I moved the check of Python 3 or later to outside the "if compressed" so it occurs in all cases.