### PR TITLE
Move sphinx-specific :doc: entry out of README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -177,5 +177,4 @@ template ``Reader`` which provides the metadata::
     ...     vcf_writer.write_record(record)
 
 An extensible script is available to filter vcf files in vcf_filter.py.  VCF filters
-declared by other packages will be available for use in this script.  Please
-see :doc:`FILTERS` for full description.
+declared by other packages will be available for use in this script.

--- a/docs/INTRO.rst
+++ b/docs/INTRO.rst
@@ -2,3 +2,5 @@ Introduction
 ============
 
 .. include:: ../README.rst
+
+Please see :doc:`FILTERS` for full description of how the filters work.


### PR DESCRIPTION
On all the releases to date, including 0.6.8, the README is treated as plain text on PyPI:
https://pypi.org/project/PyVCF/0.6.8/

This is likely because it fails validation as a standalone RST file due to a Sphinx specific extension,

```
$ pip install restructuredtext-lint
...
$ restructuredtext-lint README.rst 
ERROR README.rst:179 Unknown interpreted text role "doc".
```

This fragment also renders poorly on GitHub, showing a blue clickable but non-functional link with text:

```
 :doc:`FILTERS`
```

This pull request ensures that ``README.rst`` is a valid standalone RST file and will render cleanly on GitHub and hopefully also PyPI, while preserving the link when used as part of the main documentation's introduction.

