### PR TITLE
Define repr(_Record) using existing str method

### DIFF
--- a/vcf/model.py
+++ b/vcf/model.py
@@ -272,6 +272,9 @@ class _Record(object):
     def __str__(self):
         return "Record(CHROM=%(CHROM)s, POS=%(POS)s, REF=%(REF)s, ALT=%(ALT)s)" % self.__dict__
 
+    def __repr__(self):
+        return str(self)
+    
     def add_format(self, fmt):
         self.FORMAT = self.FORMAT + ':' + fmt
 


### PR DESCRIPTION
The existing __str__ method defines what is superficially a Python snippet which could recreate the object - and captures the key attributes.

This follows the style elsewhere in this file of using the same output for __str__ and __repr__ methods, and is useful when exploring the data interactively at the Python prompt, or in debugging logged messages.
