### PR TITLE
Fix affected_start/end with a MNP

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -156,7 +156,7 @@ for the regions of interest::
 
 Note that the start and end coordinates are in the zero-based, half-open
 coordinate system, similar to ``_Record.start`` and ``_Record.end``. The very
-first base of a chromosome is index 0, and the the region includes bases up
+first base of a chromosome is index 0, and the region includes bases up
 to, but not including the base at the end coordinate. For example::
 
     >>> # fetch all records on chromosome 4 from base 11 through 20

--- a/vcf/model.py
+++ b/vcf/model.py
@@ -205,14 +205,14 @@ class _Record(object):
 
 
     def _set_start_and_end(self):
-        self.affected_start = self.affected_end = self.POS
+        self.affected_start = self.affected_end = self.end
         for alt in self.ALT:
             if alt is None:
                 start, end = self._compute_coordinates_for_none_alt()
             elif alt.type == 'SNV':
                 start, end = self._compute_coordinates_for_snp()
             elif alt.type == 'MNV':
-                start, end = self._compute_coordinates_for_indel()
+                start, end = self._compute_coordinates_for_indel(alt)
             else:
                 start, end = self._compute_coordinates_for_sv()
             self.affected_start = min(self.affected_start, start)
@@ -235,10 +235,16 @@ class _Record(object):
         return (start, end)
 
 
-    def _compute_coordinates_for_indel(self):
+    def _compute_coordinates_for_indel(self, alt):
         if len(self.REF) > 1:
-            start = self.POS
-            end = start + (len(self.REF) - 1)
+            # get the number of leading bases that are shared between ref and alt
+            n = 0
+            for i in range(min(len(self.REF), len(alt.sequence))):
+                if self.REF[i] != alt.sequence[i]:
+                    break;
+                n += 1
+            start = self.POS + n - 1
+            end = self.POS + (len(self.REF) - 1)
         else:
             start = end = self.POS
         return (start, end)

--- a/vcf/test/test_vcf.py
+++ b/vcf/test/test_vcf.py
@@ -1189,6 +1189,25 @@ class TestRecord(unittest.TestCase):
                 None
         )
         self.assert_has_expected_coordinates(record, (9, 12), (9, 12))
+    
+    
+    def test_coordinates_for_mnp(self):
+        record = model._Record(
+                '1',
+                10,
+                'id13',
+                'AAA',
+                [
+                    model._Substitution('AAT')
+                ],
+                None,
+                None,
+                {},
+                None,
+                {},
+                None
+        )
+        self.assert_has_expected_coordinates(record, (9, 12), (11, 12))
 
 
 class TestCall(unittest.TestCase):


### PR DESCRIPTION
pyvcf does not like MNPs where the REF and ALT alleles share common bases (ex. `REF=AAA` and `ALT=AAT`). 