### PR TITLE
Allow for Invalid Position in VCF Record

### DIFF
--- a/vcf/model.py
+++ b/vcf/model.py
@@ -185,9 +185,14 @@ class _Record(object):
         self.INFO = INFO
         self.FORMAT = FORMAT
         #: zero-based, half-open start coordinate of ``REF``
-        self.start = self.POS - 1
+        if self.POS is None:
+            self.start = None
+            self.end = None
+        else:
+            self.start = self.POS - 1
+            self.end = self.start + len(self.REF)
         #: zero-based, half-open end coordinate of ``REF``
-        self.end = self.start + len(self.REF)
+
         #: list of alleles. [0] = REF, [1:] = ALTS
         self.alleles = [self.REF]
         self.alleles.extend(self.ALT)
@@ -220,12 +225,16 @@ class _Record(object):
 
 
     def _compute_coordinates_for_none_alt(self):
+        if self.POS is None:
+            return (None, None)
         start = self.POS - 1
         end = start + len(self.REF)
         return (start, end)
 
 
     def _compute_coordinates_for_snp(self):
+        if self.POS is None:
+            return (None, None)
         if len(self.REF) > 1:
             start = self.POS
             end = start + (len(self.REF) - 1)
@@ -236,6 +245,8 @@ class _Record(object):
 
 
     def _compute_coordinates_for_indel(self):
+        if self.POS is None:
+            return (None, None)
         if len(self.REF) > 1:
             start = self.POS
             end = start + (len(self.REF) - 1)
@@ -245,6 +256,8 @@ class _Record(object):
 
 
     def _compute_coordinates_for_sv(self):
+        if self.POS is None:
+            return (None, None)
         start = self.POS - 1
         end = start + len(self.REF)
         return (start, end)

--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -555,7 +555,11 @@ class Reader(object):
         chrom = row[0]
         if self._prepend_chr:
             chrom = 'chr' + chrom
-        pos = int(row[1])
+
+        try:
+            pos = int(row[1])
+        except ValueError:
+            pos = None
 
         if row[2] != '.':
             ID = row[2]

--- a/vcf/test/bad-record-character.vcf
+++ b/vcf/test/bad-record-character.vcf
@@ -1,0 +1,14 @@
+##fileformat=VCFv4.1
+##INFO=<ID=EMPTY_1,Number=1,Type=Float,Description="A floating point value">
+##INFO=<ID=EMPTY_3,Number=3,Type=Float,Description="Floating point values">
+##INFO=<ID=EMPTY_N,Number=.,Type=Float,Description="Floating point values">
+##INFO=<ID=DOT_1,Number=1,Type=Character,Description="A character value">
+##INFO=<ID=DOT_3,Number=3,Type=Character,Description="Character values">
+##INFO=<ID=DOT_N,Number=.,Type=Character,Description="Character values">
+##INFO=<ID=NOTEMPTY_1,Number=1,Type=Float,Description="A floating point value">
+##INFO=<ID=NOTEMPTY_3,Number=3,Type=Float,Description="Floating point values">
+##INFO=<ID=NOTEMPTY_N,Number=.,Type=Float,Description="Floating point values">
+##INFO=<ID=FLAG,Number=0,Type=Flag,Description="HapMap2 membership">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	Sample
+chr1	100n	id1	G	A	200n	.	FLAG;EMPTY_1=;EMPTY_3=;EMPTY_N=;DOT_1=.;DOT_3=.,.,.;DOT_N=.;NOTEMPTY_1=1;NOTEMPTY_3=1,2,3;NOTEMPTY_N=1	GT	0/1

--- a/vcf/test/test_vcf.py
+++ b/vcf/test/test_vcf.py
@@ -410,6 +410,14 @@ class TestBadInfoFields(unittest.TestCase):
         self.assertEquals(record.INFO['NOTEMPTY_N'], [1])
         pass
 
+class TestBadRecordFields(unittest.TestCase):
+    def test_parse(self):
+        reader = vcf.Reader(fh('bad-record-character.vcf'))
+        record = next(reader)
+        self.assertEquals(record.POS, None)
+        self.assertEquals(record.QUAL, None)
+        pass
+
 
 class TestParseMetaLine(unittest.TestCase):
     def test_parse(self):
@@ -1753,3 +1761,4 @@ suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestGATKMeta))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestUncalledGenotypes))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestStrelka))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestBadInfoFields))
+suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestBadRecordFields))


### PR DESCRIPTION
If a VCF file has one invalid record, we perhaps shouldn't invalidate the entire file through a `ValueError` Exception

Instead, Return `None` for `Record.POS` 