### PR TITLE
Changes to parser.py and model.py to allow for nonstandard VCF file headers

### DIFF
--- a/vcf/model.py
+++ b/vcf/model.py
@@ -195,19 +195,6 @@ class _Record(object):
 
             setattr(self, varname, value) #equivalent to: self.varname= 'something'
 
-        #=======================================================================
-        # self.CHROM = CHROM
-        # #: the one-based coordinate of the first nucleotide in ``REF``
-        # self.POS = POS
-        # self.ID = ID
-        # self.REF = REF
-        # self.ALT = ALT
-        # self.QUAL = QUAL
-        # self.FILTER = FILTER
-        # self.INFO = INFO
-        # self.FORMAT = FORMAT
-        #=======================================================================
-        
         #: zero-based, half-open start coordinate of ``REF``
         self.start = self.POS - 1
         #: zero-based, half-open end coordinate of ``REF``
@@ -294,8 +281,20 @@ class _Record(object):
         return iter(self.samples)
 
     def __str__(self):
-        return "Record(CHROM=%(CHROM)s, POS=%(POS)s, REF=%(REF)s, ALT=%(ALT)s)" % self.__dict__
-
+#        return "Record(CHROM=%(CHROM)s, POS=%(POS)s, REF=%(REF)s, ALT=%(ALT)s)" % self.__dict__
+        return ''.join(["Record(",
+                        "CHROM=%(CHROM)s, ",
+                        "POS=%(POS)s, ",
+                        "ID=%(ID)s, ",
+                        "REF=%(REF)s, ",
+                        "ALT=%(ALT)s), "
+                        "QUAL=%(QUAL)s), "
+                        "FILTER=%(FILTER)s), "
+                        "INFO=%(INFO)s), "
+                        "FORMAT=%(FORMAT)s)"
+                        ]) % self.__dict__
+                        
+#    CHROM, POS, ID, REF, ALT, QUAL, FILTER, INFO, FORMAT
     def add_format(self, fmt):
         self.FORMAT = self.FORMAT + ':' + fmt
 

--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -454,6 +454,10 @@ class Reader(object):
         return samp_fmt
 
     def _parse_samples(self, samples, samp_fmt, site):
+        print("-----------------------------")#333
+        print("samples =", samples) #3333
+        print("samp_fmt =", samp_fmt)#3333
+        print("site =", site) #333
         '''Parse a sample entry according to the format specified in the FORMAT
         column.
 
@@ -466,6 +470,7 @@ class Reader(object):
             self._format_cache[samp_fmt] = self._parse_sample_format(samp_fmt)
         samp_fmt = self._format_cache[samp_fmt]
 
+        print("cparse=", cparse)#333
         if cparse:
             return cparse.parse_samples(
                 self.samples, samples, samp_fmt, samp_fmt._types, samp_fmt._nums, site)
@@ -474,13 +479,16 @@ class Reader(object):
         _map = self._map
 
         nfields = len(samp_fmt._fields)
-
+        
+        print("self.samples", self.samples) #3333
+        print("samples =", samples)#3333
         for name, sample in zip(self.samples, samples):
-
+            print("Zipped: ", name, sample) #333
             # parse the data for this sample
             sampdat = [None] * nfields
 
             for i, vals in enumerate(sample.split(':')):
+                print("sample split = ", i, ":", vals)#333
 
                 # short circuit the most common
                 if samp_fmt._fields[i] == 'GT':
@@ -633,7 +641,6 @@ class Reader(object):
         # Genotype fields can be followed by other data columns, 
         # so we have to detect that
         if rowdict["FORMAT"] is not None:
-            items = list(rowdict.items())
             # We run this code here, because we have to wait for the first line 
             # of actual data. 
             # It will use the number of colons found in the FORMAT field, to 
@@ -654,12 +661,14 @@ class Reader(object):
                 self._sample_indexes = dict([(x,i) for (i,x) in enumerate(self.samples)])
             record = _Record(rowdict, self._sample_indexes)
                      
-            # We will assume that the next string that follows the FORMAT 
-            # declaration is the sample data. HOWEVER, a FORMAT can have 
-            # multiple sample lines (I.e. TUMOR and CONTROL.) This will only set 
-            # the first sample data. The class "_Record" needs to be 
-            # modified in order to handle multiple sets of sample data
-            samples = self._parse_samples(items[9][1], rowdict["FORMAT"], record)
+            # Generate an "items" list (of sample data) based on the columns
+            # identified to be containing sample data. This is passed to 
+            # _parse_samples
+            items = []
+            for col in self.samples:
+                items.append(rowdict[col])
+                
+            samples = self._parse_samples(items, rowdict["FORMAT"], record)
             record.samples = samples
 
         return record

--- a/vcf/sample_filter.py
+++ b/vcf/sample_filter.py
@@ -7,7 +7,7 @@ import sys
 import warnings
 
 
-from parser import Reader, Writer
+from .parser import Reader, Writer
 
 
 class SampleFilter(object):
@@ -81,13 +81,13 @@ class SampleFilter(object):
                 # is int, check if it's an idx
                 if item < len(self.samples):
                     return item
-        filters = set(filter(lambda x: x is not None, map(filt2idx, filt_s)))
+        filters = set([x for x in map(filt2idx, filt_s) if x is not None])
         if len(filters) < len(filt_s):
             # TODO print the filters that were ignored
             warnings.warn("Invalid filters, ignoring", RuntimeWarning)
 
         if self.invert:
-            filters = set(xrange(len(self.samples))).difference(filters)
+            filters = set(range(len(self.samples))).difference(filters)
 
         # `sample_filter` setter updates `samples`
         self.parser.sample_filter = filters

--- a/vcf/utils.py
+++ b/vcf/utils.py
@@ -37,19 +37,19 @@ def walk_together(*readers, **kwargs):
         next_idx_to_k = dict(
             (i, get_key(r)) for i, r in enumerate(nexts) if r is not None)
         keys_with_prev_contig = [
-            k for k in next_idx_to_k.values() if k[0] == min_k[0]]
+            k for k in list(next_idx_to_k.values()) if k[0] == min_k[0]]
 
         if any(keys_with_prev_contig):
             min_k = min(keys_with_prev_contig)   # finish previous contig
         else:
             min_k = min(next_idx_to_k.values())   # move on to next contig
 
-        min_k_idxs = set([i for i, k in next_idx_to_k.items() if k == min_k])
+        min_k_idxs = set([i for i, k in list(next_idx_to_k.items()) if k == min_k])
         yield [nexts[i] if i in min_k_idxs else None for i in range(len(nexts))]
 
         for i in min_k_idxs:
             try:
-                nexts[i] = readers[i].next()
+                nexts[i] = next(readers[i])
             except StopIteration:
                 nexts[i] = None
 


### PR DESCRIPTION
This is in regards to issue "Custom section delimited by ";" and not ":" #325

As it turns out, the issue was not the demilmiter, it was that the VCF file had additional non-standard headers and columns that came after the Genotype fields. These columns contained info similarly formatted like the INFO column. It contained data with colons (such as `GENEINFO=PRDM2:7799`) which the Genotype parser attempted to add into the Genotype "samples" list. Since it didn't match the expected format of "GT:GL:GOF:GQ:NR:NV" the code crashed (it split the line on at the GENEINFO=PRDM2[\n]7799` creating a garbage row it couldn't parse.)

I modified the code to accept VCF files with additional non-standard headers/columns. In `parser.py`, `__next__()` method you used a list "row" which is accessed by hardcoded indexes (`row[0] - row[9]`). I replaced this with a dictionary which is derived by parsing the headers row (identified by starting with `#CHROM`). It then uses the headers as dict keys, and (for each row) creates a "rowdict" variable containing "header1":"col_1_data", "header2":"col_2_data". This way, additional nonstandard columns don't crash the software. 

However, I did _not_ go so far as to modify the `_parse_samples()` method, so (right now, in this code) the additional columns are still being added to the Genotype samples. 

I just thought I would pass this code up as a pull request so you could decide if there's any value for it in the master PyVCF. 

Thanks!
Mike
